### PR TITLE
Fix API namespaces

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -196,9 +196,9 @@ func (a *API) router() http.Handler {
 		// GET /bookings/rates/received (DEPRECATED)
 		log.Info().Msg("register route GET /bookings/rates/received (DEPRECATED)")
 		r.Get("/bookings/rates/received", a.routerHandler(a.HandleGetReceivedRatings))
-		// GET /user/{id}/rates
-		log.Info().Msg("register route GET /user/{id}/rates")
-		r.Get("/user/{id}/rates", a.routerHandler(a.HandleGetUserRatings))
+		// GET /users/{id}/rates
+		log.Info().Msg("register route GET /users/{id}/rates")
+		r.Get("/users/{id}/rates", a.routerHandler(a.HandleGetUserRatings))
 		// POST /bookings/{bookingId}/rate
 		log.Info().Msg("register route POST /bookings/{bookingId}/rate")
 		r.Post("/bookings/{bookingId}/rate", a.routerHandler(a.HandleRateBooking))

--- a/api/bookings.go
+++ b/api/bookings.go
@@ -404,7 +404,7 @@ func (a *API) HandleGetReceivedRatings(r *Request) (interface{}, error) {
 	return ratings, nil
 }
 
-// HandleGetUserRatings handles GET /user/{id}/rates
+// HandleGetUserRatings handles GET /users/{id}/rates
 // Returns a unified list of all ratings (both submitted and received) for a user
 func (a *API) HandleGetUserRatings(r *Request) (interface{}, error) {
 	if r.UserID == "" {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -529,6 +529,38 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserProfile'
 
+  /users/{id}/rates:
+    get:
+      tags:
+        - User
+      summary: Get unified ratings for a user
+      description: Get all ratings (both submitted and received) for a user, grouped by booking
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: objectid
+            description: MongoDB ObjectID of the user
+      responses:
+        '200':
+          description: List of unified ratings
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UnifiedRating'
+        '400':
+          description: Invalid user ID
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal server error
+
   /images/{hash}:
     get:
       tags:
@@ -736,7 +768,7 @@ paths:
         - name: id
           in: path
           required: true
-          schema:
+          schema:rate
             type: integer
             format: int64
       responses:
@@ -746,39 +778,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Tool'
-
-  /tools/{id}/rates:
-    get:
-      tags:
-        - Tools
-      summary: Get ratings for a tool
-      description: Get all ratings associated with a tool's bookings
-      security:
-        - bearerAuth: [ ]
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        '200':
-          description: List of unified ratings for the tool
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/UnifiedRating'
-        '400':
-          description: Invalid tool ID
-        '401':
-          description: Unauthorized
-        '404':
-          description: Tool not found
-        '500':
-          description: Internal server error
     put:
       tags:
         - Tools
@@ -817,6 +816,39 @@ paths:
       responses:
         '200':
           description: Tool deleted successfully
+
+  /tools/{id}/rates:
+    get:
+      tags:
+        - Tools
+      summary: Get ratings for a tool
+      description: Get all ratings associated with a tool's bookings
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: List of unified ratings for the tool
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UnifiedRating'
+        '400':
+          description: Invalid tool ID
+        '401':
+          description: Unauthorized
+        '404':
+          description: Tool not found
+        '500':
+          description: Internal server error
 
   /bookings:
     post:
@@ -1100,38 +1132,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RatingResponse'
-        '401':
-          description: Unauthorized
-        '500':
-          description: Internal server error
-          
-  /user/{id}/rates:
-    get:
-      tags:
-        - Bookings
-      summary: Get unified ratings for a user
-      description: Get all ratings (both submitted and received) for a user, grouped by booking
-      security:
-        - bearerAuth: [ ]
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: objectid
-            description: MongoDB ObjectID of the user
-      responses:
-        '200':
-          description: List of unified ratings
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/UnifiedRating'
-        '400':
-          description: Invalid user ID
         '401':
           description: Unauthorized
         '500':

--- a/test/booking_test.go
+++ b/test/booking_test.go
@@ -658,7 +658,7 @@ func TestBookings(t *testing.T) {
 			qt.Assert(t, code, qt.Equals, 200)
 
 			// Get unified ratings for the renter
-			resp, code = c.Request(http.MethodGet, renterJWT, nil, "user", renterID, "rates")
+			resp, code = c.Request(http.MethodGet, renterJWT, nil, "users", renterID, "rates")
 			qt.Assert(t, code, qt.Equals, 200)
 
 			var unifiedResp struct {
@@ -698,7 +698,7 @@ func TestBookings(t *testing.T) {
 
 			// Get unified ratings for the owner
 			ownerID := bookingResp.Data.ToUserID
-			resp, code = c.Request(http.MethodGet, ownerJWT, nil, "user", ownerID, "rates")
+			resp, code = c.Request(http.MethodGet, ownerJWT, nil, "users", ownerID, "rates")
 			qt.Assert(t, code, qt.Equals, 200)
 
 			err = json.Unmarshal(resp, &unifiedResp)


### PR DESCRIPTION
On the **api**:

- Refactor `/user/{id}/rates` to be on the correct namespace `/users/{id}/rates`
- Fix tests according new endpoints

On **swagger**:
- Set `GET /user/{id}/rates`  to the correct swagger tag
- Change `GET /user/{id}/rates`  to be `users` 
- Move `PUT&DELETE /tools/{id}` to its correct place to respect swagger order

