### PR TITLE
Add booking date validation

### DIFF
--- a/api/bookings.go
+++ b/api/bookings.go
@@ -506,7 +506,7 @@ func (a *API) HandleCreateBooking(r *Request) (interface{}, error) {
 
 	toolID, err := strconv.ParseInt(req.ToolID, 10, 64)
 	if err != nil {
-		return nil, ErrInvalidRequestBodyData.WithErr(err)
+		return nil, ErrInvalidRequestBodyData.WithErr(fmt.Errorf("invalid tool ID format: %s", req.ToolID))
 	}
 
 	// Get tool to verify it exists and get owner ID
@@ -520,7 +520,7 @@ func (a *API) HandleCreateBooking(r *Request) (interface{}, error) {
 
 	toUser, err := a.database.UserService.GetUserByID(r.Context.Request.Context(), tool.UserID)
 	if err != nil {
-		return nil, ErrUserNotFound.WithErr(err)
+		return nil, ErrUserNotFound.WithErr(fmt.Errorf("tool owner not found: %w", err))
 	}
 
 	// Validate dates

--- a/db/booking_test.go
+++ b/db/booking_test.go
@@ -380,7 +380,8 @@ func TestBookingService_GetUnifiedRatings(t *testing.T) {
 	pendingRatings, err := bookingService.GetPendingRatings(ctx, fromUser.ID)
 	qt.Assert(t, err, qt.IsNil, qt.Commentf("Failed to get pending ratings"))
 	qt.Assert(t, len(pendingRatings), qt.Equals, 1, qt.Commentf("Expected 1 pending rating"))
-	qt.Assert(t, pendingRatings[0].ID, qt.Equals, pendingRatingBooking.ID, qt.Commentf("Expected pending rating booking ID to match"))
+	qt.Assert(t, pendingRatings[0].ID, qt.Equals, pendingRatingBooking.ID,
+		qt.Commentf("Expected pending rating booking ID to match"))
 
 	// Test 2: Verify that GetUnifiedRatings excludes the pending rating booking
 	unifiedRatings, err := bookingService.GetUnifiedRatings(ctx, fromUser.ID)
@@ -390,11 +391,13 @@ func TestBookingService_GetUnifiedRatings(t *testing.T) {
 	qt.Assert(t, len(unifiedRatings), qt.Equals, 1, qt.Commentf("Expected 1 unified rating (only the accepted booking)"))
 
 	// Verify that the unified rating is for the accepted booking
-	qt.Assert(t, unifiedRatings[0].BookingID, qt.Equals, acceptedBooking.ID, qt.Commentf("Expected unified rating booking ID to match accepted booking ID"))
+	qt.Assert(t, unifiedRatings[0].BookingID, qt.Equals, acceptedBooking.ID,
+		qt.Commentf("Expected unified rating booking ID to match accepted booking ID"))
 
 	// Verify that the pending rating booking is not included
 	for _, ur := range unifiedRatings {
-		qt.Assert(t, ur.BookingID, qt.Not(qt.Equals), pendingRatingBooking.ID, qt.Commentf("Pending rating booking should not be included in unified ratings"))
+		qt.Assert(t, ur.BookingID, qt.Not(qt.Equals), pendingRatingBooking.ID,
+			qt.Commentf("Pending rating booking should not be included in unified ratings"))
 	}
 }
 

--- a/test/booking_test.go
+++ b/test/booking_test.go
@@ -23,6 +23,61 @@ func TestBookings(t *testing.T) {
 	// Owner creates a tool
 	toolID := c.CreateTool(ownerJWT, "Test Tool")
 
+	t.Run("Date Validation", func(t *testing.T) {
+		// Test case 1: Start date before today (should fail)
+		yesterday := time.Now().Add(-24 * time.Hour)
+		tomorrow := time.Now().Add(24 * time.Hour)
+		
+		data, code := c.Request(http.MethodPost, renterJWT,
+			api.CreateBookingRequest{
+				ToolID:    fmt.Sprint(toolID),
+				StartDate: yesterday.Unix(),
+				EndDate:   tomorrow.Unix(),
+				Contact:   "test@example.com",
+				Comments:  "Test booking with invalid start date",
+			},
+			"bookings",
+		)
+		qt.Assert(t, code, qt.Equals, 400)
+		qt.Assert(t, string(data), qt.Contains, "start date must not be before today")
+
+		// Test case 2: End date before start date (should fail)
+		dayAfterTomorrow := time.Now().Add(48 * time.Hour)
+		
+		data, code = c.Request(http.MethodPost, renterJWT,
+			api.CreateBookingRequest{
+				ToolID:    fmt.Sprint(toolID),
+				StartDate: dayAfterTomorrow.Unix(),
+				EndDate:   tomorrow.Unix(),
+				Contact:   "test@example.com",
+				Comments:  "Test booking with invalid end date",
+			},
+			"bookings",
+		)
+		qt.Assert(t, code, qt.Equals, 400)
+		qt.Assert(t, string(data), qt.Contains, "end date must not be before start date")
+
+		// Test case 3: Valid dates (should succeed)
+		data, code = c.Request(http.MethodPost, renterJWT,
+			api.CreateBookingRequest{
+				ToolID:    fmt.Sprint(toolID),
+				StartDate: tomorrow.Unix(),
+				EndDate:   dayAfterTomorrow.Unix(),
+				Contact:   "test@example.com",
+				Comments:  "Test booking with valid dates",
+			},
+			"bookings",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+		
+		var response struct {
+			Data api.BookingResponse `json:"data"`
+		}
+		err := json.Unmarshal(data, &response)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, response.Data.ToolID, qt.Equals, fmt.Sprint(toolID))
+	})
+
 	t.Run("Create Booking", func(t *testing.T) {
 		// Try to create booking without auth
 		_, code := c.Request(http.MethodPost, "",

--- a/test/booking_test.go
+++ b/test/booking_test.go
@@ -740,7 +740,7 @@ func TestBookings(t *testing.T) {
 		yesterday := time.Now().Add(-24 * time.Hour)
 		tomorrow := time.Now().Add(24 * time.Hour)
 
-		data, code := c.Request(http.MethodPost, renterJWT,
+		_, code := c.Request(http.MethodPost, renterJWT,
 			api.CreateBookingRequest{
 				ToolID:    fmt.Sprint(toolID),
 				StartDate: yesterday.Unix(),
@@ -754,7 +754,7 @@ func TestBookings(t *testing.T) {
 
 		// Test case 2: End date before start date (should fail)
 		dayAfterTomorrow := time.Now().Add(48 * time.Hour)
-		data, code = c.Request(http.MethodPost, renterJWT,
+		_, code = c.Request(http.MethodPost, renterJWT,
 			api.CreateBookingRequest{
 				ToolID:    fmt.Sprint(toolID),
 				StartDate: dayAfterTomorrow.Unix(),
@@ -767,7 +767,7 @@ func TestBookings(t *testing.T) {
 		qt.Assert(t, code, qt.Equals, 400)
 
 		// Test case 3: Valid dates (should succeed)
-		data, code = c.Request(http.MethodPost, renterJWT,
+		data, code := c.Request(http.MethodPost, renterJWT,
 			api.CreateBookingRequest{
 				ToolID:    fmt.Sprint(toolID),
 				StartDate: tomorrow.Unix(),

--- a/test/tools_test.go
+++ b/test/tools_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/emprius/emprius-app-backend/api"
 	"github.com/emprius/emprius-app-backend/db"
@@ -454,12 +455,15 @@ func TestTools(t *testing.T) {
 		// Create another user to book and rate the tool
 		renterJWT := c.RegisterAndLogin("renter@test.com", "renter", "renterpass")
 
+		tomorrow := time.Now().Add(24 * time.Hour)
+		dayAfterTomorrow := time.Now().Add(48 * time.Hour)
+
 		// Create a booking
 		resp, code = c.Request(http.MethodPost, renterJWT,
 			api.CreateBookingRequest{
 				ToolID:    fmt.Sprint(toolID),
-				StartDate: 1710633600, // 2024-03-17
-				EndDate:   1710720000, // 2024-03-18
+				StartDate: tomorrow.Unix(),         // 2024-03-17
+				EndDate:   dayAfterTomorrow.Unix(), // 2024-03-18
 				Contact:   "contact info",
 				Comments:  "booking comments",
 			},


### PR DESCRIPTION
Fix #66 

- It also fixes a duplicated code that was on api.go that makes test not passing
- It updates error code on tests from 500 to 400 because now booking dates conflict is handled properly
- Fixes a rating test that not passes because of the new booking date assertions 