### PR TITLE
Ratings bulkfix

### DIFF
--- a/db/ratings.go
+++ b/db/ratings.go
@@ -265,7 +265,7 @@ func (s *BookingService) GetRatingsByToolID(ctx context.Context, toolID string) 
 		bookingIDs = append(bookingIDs, booking.ID)
 	}
 
-	// Get all ratings for these bookings that have a score
+	// Get all ratings for these bookings
 	ratingFilter := bson.M{
 		"bookingId": bson.M{"$in": bookingIDs},
 	}
@@ -442,7 +442,7 @@ func (s *BookingService) GetUnifiedRatings(ctx context.Context, userID primitive
 		bookingIDs = append(bookingIDs, booking.ID)
 	}
 
-	// Get all ratings for these bookings that have a score
+	// Get all ratings for these bookings
 	ratingFilter := bson.M{
 		"bookingId": bson.M{"$in": bookingIDs},
 	}

--- a/db/ratings.go
+++ b/db/ratings.go
@@ -268,7 +268,6 @@ func (s *BookingService) GetRatingsByToolID(ctx context.Context, toolID string) 
 	// Get all ratings for these bookings that have a score
 	ratingFilter := bson.M{
 		"bookingId": bson.M{"$in": bookingIDs},
-		"score":     bson.M{"$gt": 0}, // Only get ratings with a score
 	}
 
 	// Use options to sort by createdAt in descending order (newest first)
@@ -369,7 +368,6 @@ func (s *BookingService) GetRatingsByToolID(ctx context.Context, toolID string) 
 func (s *BookingService) GetRatingsByBookingID(ctx context.Context, bookingID primitive.ObjectID) ([]*BookingRating, error) {
 	filter := bson.M{
 		"bookingId": bookingID,
-		"score":     bson.M{"$gt": 0}, // Only get ratings with a score
 	}
 
 	// Use options to sort by createdAt in descending order (newest first)
@@ -447,7 +445,6 @@ func (s *BookingService) GetUnifiedRatings(ctx context.Context, userID primitive
 	// Get all ratings for these bookings that have a score
 	ratingFilter := bson.M{
 		"bookingId": bson.M{"$in": bookingIDs},
-		"score":     bson.M{"$gt": 0}, // Only get ratings with a score
 	}
 
 	// Use options to sort by createdAt in descending order (newest first)
@@ -480,10 +477,6 @@ func (s *BookingService) GetUnifiedRatings(ctx context.Context, userID primitive
 	// Sort bookings by createdAt in descending order (newest first)
 	var sortedBookings []*Booking
 	for _, booking := range bookingMap {
-		// Skip bookings that are in the pending ratings list for this user
-		if pendingBookingIDs[booking.ID] {
-			continue
-		}
 		sortedBookings = append(sortedBookings, booking)
 	}
 


### PR DESCRIPTION
Fix https://github.com/emprius/emprius-app-backend/issues/60
And fix also some of the https://github.com/emprius/emprius-app-backend/issues/65: GET /tool/{toolId}/rates return empty rating object when for bookings that are not returned yet. On the following example the booking have ACCEPTED status:

- It refactors a bit adding a check

```go
// Check if there are any ratings for this booking
		bookingRatings, hasRatings := ratingsByBooking[bookingID]
		if !hasRatings {
			// Skip bookings with no ratings
			continue
		}
```

- Also delete a code that seems to be added on previous versions and is not needed: 

https://github.com/emprius/emprius-app-backend/pull/80/files#diff-a8d23fed8ff23621ada6976f2e9c8c24b8323b3dba140b05efc9f5bc57ea357aL475-L478

This above code fixes this bug: https://github.com/emprius/emprius-app-backend/issues/60#issuecomment-2750399480