### PR TITLE
Improve docker file to use docker compose cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,22 @@
 FROM golang:alpine AS builder
 
+# Install deps
+RUN apk update && apk add --no-cache build-base
+
+# Set working directory
 WORKDIR /src
+
+# Copy only go.mod and go.sum first (they rarely change)
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the rest of the code
 COPY . .
-RUN apk update && apk add build-base
+
+# Build the binary
 RUN go build -o=empriusbackend -ldflags="-s -w"
 
+# Final minimal image
 FROM alpine:latest
 
 WORKDIR /app


### PR DESCRIPTION
On this way, the packages are not download every time `docker compose build` is executed