### PR TITLE
Implement user communities

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -178,9 +178,9 @@ func (a *API) router() http.Handler {
 		// DELETE /communities/{communityId}
 		log.Info().Msg("register route DELETE /communities/{communityId}")
 		r.Delete("/communities/{communityId}", a.routerHandler(a.deleteCommunityHandler))
-		// GET /communities/{communityId}/users
-		log.Info().Msg("register route GET /communities/{communityId}/users")
-		r.Get("/communities/{communityId}/users", a.routerHandler(a.getCommunityUsersHandler))
+		// GET /communities/{communityId}/members
+		log.Info().Msg("register route GET /communities/{communityId}/members")
+		r.Get("/communities/{communityId}/members", a.routerHandler(a.getCommunityUsersHandler))
 		// POST /communities/{communityId}/members/{userId} - Invite user to community
 		log.Info().Msg("register route POST /communities/{communityId}/members/{userId}")
 		r.Post("/communities/{communityId}/members/{userId}", a.routerHandler(a.inviteUserToCommunityHandler))

--- a/api/api.go
+++ b/api/api.go
@@ -107,6 +107,9 @@ func (a *API) router() http.Handler {
 		// GET /users/{id}/ratings
 		log.Info().Msg("register route GET /users/{id}/ratings")
 		r.Get("/users/{id}/ratings", a.routerHandler(a.HandleGetUserRatings))
+		// GET /users/{userId}/communities - Get communities for a specific user
+		log.Info().Msg("register route GET /users/{userId}/communities")
+		r.Get("/users/{userId}/communities", a.routerHandler(a.getUserCommunitiesHandler))
 
 		// Images
 		// POST /images

--- a/api/api.go
+++ b/api/api.go
@@ -184,6 +184,9 @@ func (a *API) router() http.Handler {
 		// GET /communities/{communityId}/members
 		log.Info().Msg("register route GET /communities/{communityId}/members")
 		r.Get("/communities/{communityId}/members", a.routerHandler(a.getCommunityUsersHandler))
+		// GET /communities/{communityId}/tools
+		log.Info().Msg("register route GET /communities/{communityId}/tools")
+		r.Get("/communities/{communityId}/tools", a.routerHandler(a.getCommunityToolsHandler))
 		// POST /communities/{communityId}/members/{userId} - Invite user to community
 		log.Info().Msg("register route POST /communities/{communityId}/members/{userId}")
 		r.Post("/communities/{communityId}/members/{userId}", a.routerHandler(a.inviteUserToCommunityHandler))

--- a/api/api.go
+++ b/api/api.go
@@ -187,7 +187,10 @@ func (a *API) router() http.Handler {
 		// POST /communities/{communityId}/members/{userId} - Invite user to community
 		log.Info().Msg("register route POST /communities/{communityId}/members/{userId}")
 		r.Post("/communities/{communityId}/members/{userId}", a.routerHandler(a.inviteUserToCommunityHandler))
-		// DELETE /communities/{communityId}/members/{userId} - Remove user from community (leave)
+		// DELETE /communities/{communityId}/members} - Remove leave community
+		log.Info().Msg("register route DELETE /communities/{communityId}/members")
+		r.Delete("/communities/{communityId}/members", a.routerHandler(a.leaveCommunityHandler))
+		// DELETE /communities/{communityId}/members/{userId} - Remove user from community
 		log.Info().Msg("register route DELETE /communities/{communityId}/members/{userId}")
 		r.Delete("/communities/{communityId}/members/{userId}", a.routerHandler(a.leaveCommunityHandler))
 		// GET /communities/invites - Get authenticated user's pending invites

--- a/api/api.go
+++ b/api/api.go
@@ -94,8 +94,12 @@ func (a *API) router() http.Handler {
 		r.Get("/profile/pendings", a.routerHandler(a.HandleCountPendingActions))
 		log.Info().Msg("register route GET /refresh")
 		r.Get("/refresh", a.routerHandler(a.refreshHandler))
+		log.Info().Msg("register route GET /profile")
+		r.Get("/profile", a.routerHandler(a.userProfileHandler))
 		log.Info().Msg("register route POST /profile")
 		r.Post("/profile", a.routerHandler(a.userProfileUpdateHandler))
+		log.Info().Msg("register route GET /profile/pendings")
+		r.Get("/profile/pendings", a.routerHandler(a.HandleCountPendingActions))
 		log.Info().Msg("register route GET /users")
 		r.Get("/users", a.routerHandler(a.usersHandler))
 		log.Info().Msg("register route GET /users/{id}")
@@ -160,6 +164,39 @@ func (a *API) router() http.Handler {
 		// GET /bookings/{bookingId}/ratings
 		log.Info().Msg("register route GET /bookings/{bookingId}/ratings")
 		r.Get("/bookings/{bookingId}/ratings", a.routerHandler(a.HandleGetBookingRatings))
+
+		// Communities
+		// POST /communities
+		log.Info().Msg("register route POST /communities")
+		r.Post("/communities", a.routerHandler(a.createCommunityHandler))
+		// GET /communities/{communityId}
+		log.Info().Msg("register route GET /communities/{communityId}")
+		r.Get("/communities/{communityId}", a.routerHandler(a.getCommunityHandler))
+		// PUT /communities/{communityId}
+		log.Info().Msg("register route PUT /communities/{communityId}")
+		r.Put("/communities/{communityId}", a.routerHandler(a.updateCommunityHandler))
+		// DELETE /communities/{communityId}
+		log.Info().Msg("register route DELETE /communities/{communityId}")
+		r.Delete("/communities/{communityId}", a.routerHandler(a.deleteCommunityHandler))
+		// GET /communities/{communityId}/users
+		log.Info().Msg("register route GET /communities/{communityId}/users")
+		r.Get("/communities/{communityId}/users", a.routerHandler(a.getCommunityUsersHandler))
+
+		// POST /communities/{communityId}/invite/{userId}
+		log.Info().Msg("register route POST /communities/{communityId}/invite/{userId}")
+		r.Post("/communities/{communityId}/invite/{userId}", a.routerHandler(a.inviteUserToCommunityHandler))
+		// POST /communities/{communityId}/leave
+		log.Info().Msg("register route POST /communities/{communityId}/leave")
+		r.Post("/communities/{communityId}/leave", a.routerHandler(a.leaveCommunityHandler))
+		// GET /users/invites
+		log.Info().Msg("register route GET /users/invites")
+		r.Get("/users/invites", a.routerHandler(a.getUserPendingInvitesHandler))
+		// POST /users/invites/{inviteId}/accept
+		log.Info().Msg("register route POST /users/invites/{inviteId}/accept")
+		r.Post("/users/invites/{inviteId}/accept", a.routerHandler(a.acceptInviteHandler))
+		// POST /users/invites/{inviteId}/refuse
+		log.Info().Msg("register route POST /users/invites/{inviteId}/refuse")
+		r.Post("/users/invites/{inviteId}/refuse", a.routerHandler(a.rejectInviteHandler))
 	})
 
 	// Public routes

--- a/api/api.go
+++ b/api/api.go
@@ -181,22 +181,18 @@ func (a *API) router() http.Handler {
 		// GET /communities/{communityId}/users
 		log.Info().Msg("register route GET /communities/{communityId}/users")
 		r.Get("/communities/{communityId}/users", a.routerHandler(a.getCommunityUsersHandler))
-
-		// POST /communities/{communityId}/invite/{userId}
-		log.Info().Msg("register route POST /communities/{communityId}/invite/{userId}")
-		r.Post("/communities/{communityId}/invite/{userId}", a.routerHandler(a.inviteUserToCommunityHandler))
-		// POST /communities/{communityId}/leave
-		log.Info().Msg("register route POST /communities/{communityId}/leave")
-		r.Post("/communities/{communityId}/leave", a.routerHandler(a.leaveCommunityHandler))
-		// GET /users/invites
-		log.Info().Msg("register route GET /users/invites")
-		r.Get("/users/invites", a.routerHandler(a.getUserPendingInvitesHandler))
-		// POST /users/invites/{inviteId}/accept
-		log.Info().Msg("register route POST /users/invites/{inviteId}/accept")
-		r.Post("/users/invites/{inviteId}/accept", a.routerHandler(a.acceptInviteHandler))
-		// POST /users/invites/{inviteId}/refuse
-		log.Info().Msg("register route POST /users/invites/{inviteId}/refuse")
-		r.Post("/users/invites/{inviteId}/refuse", a.routerHandler(a.rejectInviteHandler))
+		// POST /communities/{communityId}/members/{userId} - Invite user to community
+		log.Info().Msg("register route POST /communities/{communityId}/members/{userId}")
+		r.Post("/communities/{communityId}/members/{userId}", a.routerHandler(a.inviteUserToCommunityHandler))
+		// DELETE /communities/{communityId}/members/{userId} - Remove user from community (leave)
+		log.Info().Msg("register route DELETE /communities/{communityId}/members/{userId}")
+		r.Delete("/communities/{communityId}/members/{userId}", a.routerHandler(a.leaveCommunityHandler))
+		// GET /communities/invites - Get authenticated user's pending invites
+		log.Info().Msg("register route GET /communities/invites")
+		r.Get("/communities/invites", a.routerHandler(a.getUserPendingInvitesHandler))
+		// PUT /communities/invites/{inviteId} - Update invite status (accept/reject)
+		log.Info().Msg("register route PUT /communities/invites/{inviteId}")
+		r.Put("/communities/invites/{inviteId}", a.routerHandler(a.updateInviteStatusHandler))
 	})
 
 	// Public routes

--- a/api/bookings.go
+++ b/api/bookings.go
@@ -158,7 +158,7 @@ func (a *API) HandleUpdateBookingStatus(r *Request) (interface{}, error) {
 	// Validate the requested status
 	var newStatus db.BookingStatus
 	switch statusUpdate.Status {
-	case "ACCEPTED":
+	case BookingStatusAccepted:
 		newStatus = db.BookingStatusAccepted
 		// Verify user is the tool owner
 		if booking.ToUserID != user.ObjectID() {
@@ -168,7 +168,7 @@ func (a *API) HandleUpdateBookingStatus(r *Request) (interface{}, error) {
 		if booking.BookingStatus != db.BookingStatusPending {
 			return nil, ErrCanOnlyAcceptPending.WithErr(fmt.Errorf("booking status is %s", booking.BookingStatus))
 		}
-	case "REJECTED":
+	case BookingStatusRejected:
 		newStatus = db.BookingStatusRejected
 		// Verify user is the tool owner
 		if booking.ToUserID != user.ObjectID() {
@@ -178,7 +178,7 @@ func (a *API) HandleUpdateBookingStatus(r *Request) (interface{}, error) {
 		if booking.BookingStatus != db.BookingStatusPending {
 			return nil, ErrCanOnlyDenyPending.WithErr(fmt.Errorf("booking status is %s", booking.BookingStatus))
 		}
-	case "CANCELLED":
+	case BookingStatusCancelled:
 		newStatus = db.BookingStatusCancelled
 		// Verify user is the requester
 		if booking.FromUserID != user.ObjectID() {
@@ -188,7 +188,7 @@ func (a *API) HandleUpdateBookingStatus(r *Request) (interface{}, error) {
 		if booking.BookingStatus != db.BookingStatusPending {
 			return nil, ErrCanOnlyCancelPending.WithErr(fmt.Errorf("booking status is %s", booking.BookingStatus))
 		}
-	case "RETURNED":
+	case BookingStatusReturned:
 		newStatus = db.BookingStatusReturned
 		// Verify user is the tool owner
 		if booking.ToUserID != user.ObjectID() {

--- a/api/bookings.go
+++ b/api/bookings.go
@@ -476,20 +476,3 @@ func (a *API) HandleRateBooking(r *Request) (interface{}, error) {
 
 	return a.convertBookingToResponse(updatedBooking, r.UserID), nil
 }
-
-// HandleCountPendingActions handles GET /profile/pendings
-func (a *API) HandleCountPendingActions(r *Request) (interface{}, error) {
-	if r.UserID == "" {
-		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user not authenticated"))
-	}
-	uID, err := primitive.ObjectIDFromHex(r.UserID)
-	if err != nil {
-		return nil, ErrInvalidRequestBodyData.WithErr(err)
-	}
-
-	pending, err := a.database.BookingService.CountPendingActions(r.Context.Request.Context(), uID)
-	if err != nil {
-		return nil, ErrInternalServerError.WithErr(err)
-	}
-	return pending, nil
-}

--- a/api/communities.go
+++ b/api/communities.go
@@ -125,7 +125,8 @@ func (a *API) getCommunityHandler(r *Request) (interface{}, error) {
 	}
 
 	// Get community with member count and tool count
-	community, membersCount, toolsCount, err := a.database.CommunityService.GetCommunityWithMemberCount(r.Context.Request.Context(), communityID)
+	ctx := r.Context.Request.Context()
+	community, membersCount, toolsCount, err := a.database.CommunityService.GetCommunityWithMemberCount(ctx, communityID)
 	if err != nil {
 		return nil, ErrCommunityNotFound.WithErr(err)
 	}
@@ -183,7 +184,8 @@ func (a *API) updateCommunityHandler(r *Request) (interface{}, error) {
 	}
 
 	// Get updated community with member count and tool count
-	updatedCommunity, membersCount, toolsCount, err := a.database.CommunityService.GetCommunityWithMemberCount(r.Context.Request.Context(), communityID)
+	ctx := r.Context.Request.Context()
+	updatedCommunity, membersCount, toolsCount, err := a.database.CommunityService.GetCommunityWithMemberCount(ctx, communityID)
 	if err != nil {
 		return nil, ErrInternalServerError.WithErr(err)
 	}
@@ -547,7 +549,8 @@ func (a *API) getUserCommunitiesHandler(r *Request) (interface{}, error) {
 	}
 
 	// Get communities for the user with member counts and tool counts
-	communities, memberCounts, toolCounts, err := a.database.CommunityService.GetUserCommunitiesWithMemberCount(r.Context.Request.Context(), userID, page)
+	ctx := r.Context.Request.Context()
+	communities, memberCounts, toolCounts, err := a.database.CommunityService.GetUserCommunitiesWithMemberCount(ctx, userID, page)
 	if err != nil {
 		return nil, ErrInternalServerError.WithErr(err)
 	}

--- a/api/communities.go
+++ b/api/communities.go
@@ -33,8 +33,7 @@ type CommunityResponse struct {
 
 // CommunityUserResponse represents a user in a community
 type CommunityUserResponse struct {
-	ID   string           `json:"id"`
-	Name string           `json:"name"`
+	UserPreview
 	Role db.CommunityRole `json:"role"`
 }
 
@@ -244,9 +243,8 @@ func (a *API) getCommunityUsersHandler(r *Request) (interface{}, error) {
 		}
 
 		response[i] = CommunityUserResponse{
-			ID:   user.ID.Hex(),
-			Name: user.Name,
-			Role: role,
+			UserPreview: *new(UserPreview).FromDBUserPreview(user),
+			Role:        role,
 		}
 	}
 

--- a/api/communities.go
+++ b/api/communities.go
@@ -1,0 +1,487 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/emprius/emprius-app-backend/db"
+	"github.com/go-chi/chi/v5"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// CreateCommunityRequest represents the request to create a new community
+type CreateCommunityRequest struct {
+	Name      string `json:"name"`
+	ImageHash []byte `json:"imageHash,omitempty"`
+}
+
+// UpdateCommunityRequest represents the request to update a community
+type UpdateCommunityRequest struct {
+	Name      string `json:"name,omitempty"`
+	ImageHash []byte `json:"imageHash,omitempty"`
+}
+
+// CommunityResponse represents a community in API responses
+type CommunityResponse struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	ImageHash []byte `json:"imageHash,omitempty"`
+	OwnerID   string `json:"ownerId"`
+}
+
+// CommunityUserResponse represents a user in a community
+type CommunityUserResponse struct {
+	ID   string           `json:"id"`
+	Name string           `json:"name"`
+	Role db.CommunityRole `json:"role"`
+}
+
+// CommunityInviteResponse represents a community invitation
+type CommunityInviteResponse struct {
+	ID          string `json:"id"`
+	CommunityID string `json:"communityId"`
+	UserID      string `json:"userId"`
+	InviterID   string `json:"inviterId"`
+	Status      string `json:"status"`
+}
+
+// createCommunityHandler handles POST /communities
+func (a *API) createCommunityHandler(r *Request) (interface{}, error) {
+	if r.UserID == "" {
+		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user not authenticated"))
+	}
+
+	var req CreateCommunityRequest
+	if err := json.Unmarshal(r.Data, &req); err != nil {
+		return nil, ErrInvalidRequestBodyData.WithErr(err)
+	}
+
+	// Validate request
+	if req.Name == "" {
+		return nil, ErrInvalidRequestBodyData.WithErr(fmt.Errorf("community name is required"))
+	}
+
+	// Get user ID
+	userID, err := primitive.ObjectIDFromHex(r.UserID)
+	if err != nil {
+		return nil, ErrInvalidUserID.WithErr(err)
+	}
+
+	// Create community
+	community, err := a.database.CommunityService.CreateCommunity(r.Context.Request.Context(), req.Name, req.ImageHash, userID)
+	if err != nil {
+		return nil, ErrInternalServerError.WithErr(err)
+	}
+
+	// Return response
+	return &CommunityResponse{
+		ID:        community.ID.Hex(),
+		Name:      community.Name,
+		ImageHash: community.ImageHash,
+		OwnerID:   community.OwnerID.Hex(),
+	}, nil
+}
+
+// getCommunityHandler handles GET /communities/{communityId}
+func (a *API) getCommunityHandler(r *Request) (interface{}, error) {
+	if r.UserID == "" {
+		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user not authenticated"))
+	}
+
+	// Get community ID from URL
+	communityIDStr := chi.URLParam(r.Context.Request, "communityId")
+	communityID, err := primitive.ObjectIDFromHex(communityIDStr)
+	if err != nil {
+		return nil, ErrInvalidRequestBodyData.WithErr(err)
+	}
+
+	// Get community
+	community, err := a.database.CommunityService.GetCommunity(r.Context.Request.Context(), communityID)
+	if err != nil {
+		return nil, ErrInternalServerError.WithErr(err)
+	}
+
+	// Return response
+	return &CommunityResponse{
+		ID:        community.ID.Hex(),
+		Name:      community.Name,
+		ImageHash: community.ImageHash,
+		OwnerID:   community.OwnerID.Hex(),
+	}, nil
+}
+
+// updateCommunityHandler handles PUT /communities/{communityId}
+func (a *API) updateCommunityHandler(r *Request) (interface{}, error) {
+	if r.UserID == "" {
+		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user not authenticated"))
+	}
+
+	// Get community ID from URL
+	communityIDStr := chi.URLParam(r.Context.Request, "communityId")
+	communityID, err := primitive.ObjectIDFromHex(communityIDStr)
+	if err != nil {
+		return nil, ErrInvalidRequestBodyData.WithErr(err)
+	}
+
+	// Parse request
+	var req UpdateCommunityRequest
+	if err := json.Unmarshal(r.Data, &req); err != nil {
+		return nil, ErrInvalidRequestBodyData.WithErr(err)
+	}
+
+	// Get community to check ownership
+	community, err := a.database.CommunityService.GetCommunity(r.Context.Request.Context(), communityID)
+	if err != nil {
+		return nil, ErrInternalServerError.WithErr(err)
+	}
+
+	// Check if user is the owner
+	userID, err := primitive.ObjectIDFromHex(r.UserID)
+	if err != nil {
+		return nil, ErrInvalidUserID.WithErr(err)
+	}
+
+	if community.OwnerID != userID {
+		return nil, ErrUnauthorized.WithErr(fmt.Errorf("only the community owner can update the community"))
+	}
+
+	// Update community
+	err = a.database.CommunityService.UpdateCommunity(r.Context.Request.Context(), communityID, req.Name, req.ImageHash)
+	if err != nil {
+		return nil, ErrInternalServerError.WithErr(err)
+	}
+
+	// Get updated community
+	updatedCommunity, err := a.database.CommunityService.GetCommunity(r.Context.Request.Context(), communityID)
+	if err != nil {
+		return nil, ErrInternalServerError.WithErr(err)
+	}
+
+	// Return response
+	return &CommunityResponse{
+		ID:        updatedCommunity.ID.Hex(),
+		Name:      updatedCommunity.Name,
+		ImageHash: updatedCommunity.ImageHash,
+		OwnerID:   updatedCommunity.OwnerID.Hex(),
+	}, nil
+}
+
+// deleteCommunityHandler handles DELETE /communities/{communityId}
+func (a *API) deleteCommunityHandler(r *Request) (interface{}, error) {
+	if r.UserID == "" {
+		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user not authenticated"))
+	}
+
+	// Get community ID from URL
+	communityIDStr := chi.URLParam(r.Context.Request, "communityId")
+	communityID, err := primitive.ObjectIDFromHex(communityIDStr)
+	if err != nil {
+		return nil, ErrInvalidRequestBodyData.WithErr(err)
+	}
+
+	// Get community to check ownership
+	community, err := a.database.CommunityService.GetCommunity(r.Context.Request.Context(), communityID)
+	if err != nil {
+		return nil, ErrInternalServerError.WithErr(err)
+	}
+
+	// Check if user is the owner
+	userID, err := primitive.ObjectIDFromHex(r.UserID)
+	if err != nil {
+		return nil, ErrInvalidUserID.WithErr(err)
+	}
+
+	if community.OwnerID != userID {
+		return nil, ErrUnauthorized.WithErr(fmt.Errorf("only the community owner can delete the community"))
+	}
+
+	// Delete community
+	err = a.database.CommunityService.DeleteCommunity(r.Context.Request.Context(), communityID)
+	if err != nil {
+		return nil, ErrInternalServerError.WithErr(err)
+	}
+
+	return nil, nil
+}
+
+// getCommunityUsersHandler handles GET /communities/{communityId}/users
+func (a *API) getCommunityUsersHandler(r *Request) (interface{}, error) {
+	if r.UserID == "" {
+		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user not authenticated"))
+	}
+
+	// Get community ID from URL
+	communityIDStr := chi.URLParam(r.Context.Request, "communityId")
+	communityID, err := primitive.ObjectIDFromHex(communityIDStr)
+	if err != nil {
+		return nil, ErrInvalidRequestBodyData.WithErr(err)
+	}
+
+	// Get page from query parameters
+	page, err := r.Context.GetPage()
+	if err != nil {
+		return nil, ErrInvalidRequestBodyData.WithErr(err)
+	}
+
+	// Get community users
+	users, err := a.database.CommunityService.GetCommunityUsers(r.Context.Request.Context(), communityID, page)
+	if err != nil {
+		return nil, ErrInternalServerError.WithErr(err)
+	}
+
+	// Convert to response format
+	response := make([]CommunityUserResponse, len(users))
+	for i, user := range users {
+		// Find user's role in this community
+		var role db.CommunityRole
+		for _, comm := range user.Communities {
+			if comm.ID == communityID {
+				role = comm.Role
+				break
+			}
+		}
+
+		response[i] = CommunityUserResponse{
+			ID:   user.ID.Hex(),
+			Name: user.Name,
+			Role: role,
+		}
+	}
+
+	return response, nil
+}
+
+// inviteUserToCommunityHandler handles POST /communities/{communityId}/invite/{userId}
+func (a *API) inviteUserToCommunityHandler(r *Request) (interface{}, error) {
+	if r.UserID == "" {
+		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user not authenticated"))
+	}
+
+	// Get community ID from URL
+	communityIDStr := chi.URLParam(r.Context.Request, "communityId")
+	communityID, err := primitive.ObjectIDFromHex(communityIDStr)
+	if err != nil {
+		return nil, ErrInvalidRequestBodyData.WithErr(err)
+	}
+
+	// Get user ID from URL
+	userIDStr := chi.URLParam(r.Context.Request, "userId")
+	userID, err := primitive.ObjectIDFromHex(userIDStr)
+	if err != nil {
+		return nil, ErrInvalidRequestBodyData.WithErr(err)
+	}
+
+	// Get inviter ID
+	inviterID, err := primitive.ObjectIDFromHex(r.UserID)
+	if err != nil {
+		return nil, ErrInvalidUserID.WithErr(err)
+	}
+
+	// Create invitation
+	invite, err := a.database.CommunityService.InviteUserToCommunity(r.Context.Request.Context(), communityID, userID, inviterID)
+	if err != nil {
+		return nil, ErrInternalServerError.WithErr(err)
+	}
+
+	// Return response
+	return &CommunityInviteResponse{
+		ID:          invite.ID.Hex(),
+		CommunityID: invite.CommunityID.Hex(),
+		UserID:      invite.UserID.Hex(),
+		InviterID:   invite.InviterID.Hex(),
+		Status:      string(invite.Status),
+	}, nil
+}
+
+// leaveCommunityHandler handles POST /communities/{communityId}/leave
+func (a *API) leaveCommunityHandler(r *Request) (interface{}, error) {
+	if r.UserID == "" {
+		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user not authenticated"))
+	}
+
+	// Get community ID from URL
+	communityIDStr := chi.URLParam(r.Context.Request, "communityId")
+	communityID, err := primitive.ObjectIDFromHex(communityIDStr)
+	if err != nil {
+		return nil, ErrInvalidRequestBodyData.WithErr(err)
+	}
+
+	// Get user ID
+	userID, err := primitive.ObjectIDFromHex(r.UserID)
+	if err != nil {
+		return nil, ErrInvalidUserID.WithErr(err)
+	}
+
+	// Leave community
+	err = a.database.CommunityService.LeaveCommunity(r.Context.Request.Context(), communityID, userID)
+	if err != nil {
+		return nil, ErrInternalServerError.WithErr(err)
+	}
+
+	return nil, nil
+}
+
+// getUserPendingInvitesHandler handles GET /users/invites
+func (a *API) getUserPendingInvitesHandler(r *Request) (interface{}, error) {
+	if r.UserID == "" {
+		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user not authenticated"))
+	}
+
+	// Get user ID
+	userID, err := primitive.ObjectIDFromHex(r.UserID)
+	if err != nil {
+		return nil, ErrInvalidUserID.WithErr(err)
+	}
+
+	// Get pending invites
+	invites, err := a.database.CommunityService.GetUserPendingInvites(r.Context.Request.Context(), userID)
+	if err != nil {
+		return nil, ErrInternalServerError.WithErr(err)
+	}
+
+	// Convert to response format
+	response := make([]CommunityInviteResponse, len(invites))
+	for i, invite := range invites {
+		response[i] = CommunityInviteResponse{
+			ID:          invite.ID.Hex(),
+			CommunityID: invite.CommunityID.Hex(),
+			UserID:      invite.UserID.Hex(),
+			InviterID:   invite.InviterID.Hex(),
+			Status:      string(invite.Status),
+		}
+	}
+
+	return response, nil
+}
+
+// acceptInviteHandler handles POST /users/invites/{inviteId}/accept
+func (a *API) acceptInviteHandler(r *Request) (interface{}, error) {
+	if r.UserID == "" {
+		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user not authenticated"))
+	}
+
+	// Get invite ID from URL
+	inviteIDStr := chi.URLParam(r.Context.Request, "inviteId")
+	inviteID, err := primitive.ObjectIDFromHex(inviteIDStr)
+	if err != nil {
+		return nil, ErrInvalidRequestBodyData.WithErr(err)
+	}
+
+	// Get user ID
+	userID, err := primitive.ObjectIDFromHex(r.UserID)
+	if err != nil {
+		return nil, ErrInvalidUserID.WithErr(err)
+	}
+
+	// Accept invite
+	err = a.database.CommunityService.AcceptInvite(r.Context.Request.Context(), inviteID, userID)
+	if err != nil {
+		return nil, ErrInternalServerError.WithErr(err)
+	}
+
+	return nil, nil
+}
+
+// rejectInviteHandler handles POST /users/invites/{inviteId}/refuse
+func (a *API) rejectInviteHandler(r *Request) (interface{}, error) {
+	if r.UserID == "" {
+		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user not authenticated"))
+	}
+
+	// Get invite ID from URL
+	inviteIDStr := chi.URLParam(r.Context.Request, "inviteId")
+	inviteID, err := primitive.ObjectIDFromHex(inviteIDStr)
+	if err != nil {
+		return nil, ErrInvalidRequestBodyData.WithErr(err)
+	}
+
+	// Get user ID
+	userID, err := primitive.ObjectIDFromHex(r.UserID)
+	if err != nil {
+		return nil, ErrInvalidUserID.WithErr(err)
+	}
+
+	// Reject invite
+	err = a.database.CommunityService.RejectInvite(r.Context.Request.Context(), inviteID, userID)
+	if err != nil {
+		return nil, ErrInternalServerError.WithErr(err)
+	}
+
+	return nil, nil
+}
+
+// addToolToCommunityHandler handles adding a tool to a community
+// This is part of the tool update process in editToolHandler
+func (a *API) addToolToCommunity(ctx context.Context, toolID int64, communityIDs []string) error {
+	// Get existing tool to get its current communities
+	tool, err := a.database.ToolService.GetToolByID(ctx, toolID)
+	if err != nil {
+		return err
+	}
+
+	// Convert string IDs to ObjectIDs
+	newCommunities := make([]primitive.ObjectID, 0, len(communityIDs))
+	for _, idStr := range communityIDs {
+		id, err := primitive.ObjectIDFromHex(idStr)
+		if err != nil {
+			return ErrInvalidRequestBodyData.WithErr(fmt.Errorf("invalid community ID: %s", idStr))
+		}
+		newCommunities = append(newCommunities, id)
+	}
+
+	// Find communities to add and remove
+	currentCommunities := tool.Communities
+	toAdd := make([]primitive.ObjectID, 0)
+	toRemove := make([]primitive.ObjectID, 0)
+
+	// Find communities to add
+	for _, newComm := range newCommunities {
+		found := false
+		for _, currentComm := range currentCommunities {
+			if newComm == currentComm {
+				found = true
+				break
+			}
+		}
+		if !found {
+			toAdd = append(toAdd, newComm)
+		}
+	}
+
+	// Find communities to remove
+	for _, currentComm := range currentCommunities {
+		found := false
+		for _, newComm := range newCommunities {
+			if currentComm == newComm {
+				found = true
+				break
+			}
+		}
+		if !found {
+			toRemove = append(toRemove, currentComm)
+		}
+	}
+
+	// Add tool to new communities
+	for _, communityID := range toAdd {
+		err := a.database.CommunityService.AddToolToCommunity(ctx, toolID, communityID)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Remove tool from old communities
+	for _, communityID := range toRemove {
+		err := a.database.CommunityService.RemoveToolFromCommunity(ctx, toolID, communityID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// These methods are now integrated into the original tool handlers in tools.go
+// The functionality for handling communities with tools is now part of the
+// original tool handlers, so these methods are no longer needed.

--- a/api/communities.go
+++ b/api/communities.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/emprius/emprius-app-backend/types"
 
 	"github.com/emprius/emprius-app-backend/db"
 	"github.com/go-chi/chi/v5"
@@ -12,22 +13,22 @@ import (
 
 // CreateCommunityRequest represents the request to create a new community
 type CreateCommunityRequest struct {
-	Name      string `json:"name"`
-	ImageHash []byte `json:"imageHash,omitempty"`
+	Name  string         `json:"name"`
+	Image types.HexBytes `json:"image,omitempty"`
 }
 
 // UpdateCommunityRequest represents the request to update a community
 type UpdateCommunityRequest struct {
-	Name      string `json:"name,omitempty"`
-	ImageHash []byte `json:"imageHash,omitempty"`
+	Name  string         `json:"name,omitempty"`
+	Image types.HexBytes `json:"image,omitempty"`
 }
 
 // CommunityResponse represents a community in API responses
 type CommunityResponse struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	ImageHash []byte `json:"imageHash,omitempty"`
-	OwnerID   string `json:"ownerId"`
+	ID      string         `json:"id"`
+	Name    string         `json:"name"`
+	Image   types.HexBytes `json:"image,omitempty"`
+	OwnerID string         `json:"ownerId"`
 }
 
 // CommunityUserResponse represents a user in a community
@@ -69,17 +70,17 @@ func (a *API) createCommunityHandler(r *Request) (interface{}, error) {
 	}
 
 	// Create community
-	community, err := a.database.CommunityService.CreateCommunity(r.Context.Request.Context(), req.Name, req.ImageHash, userID)
+	community, err := a.database.CommunityService.CreateCommunity(r.Context.Request.Context(), req.Name, req.Image, userID)
 	if err != nil {
 		return nil, ErrInternalServerError.WithErr(err)
 	}
 
 	// Return response
 	return &CommunityResponse{
-		ID:        community.ID.Hex(),
-		Name:      community.Name,
-		ImageHash: community.ImageHash,
-		OwnerID:   community.OwnerID.Hex(),
+		ID:      community.ID.Hex(),
+		Name:    community.Name,
+		Image:   community.Image,
+		OwnerID: community.OwnerID.Hex(),
 	}, nil
 }
 
@@ -104,10 +105,10 @@ func (a *API) getCommunityHandler(r *Request) (interface{}, error) {
 
 	// Return response
 	return &CommunityResponse{
-		ID:        community.ID.Hex(),
-		Name:      community.Name,
-		ImageHash: community.ImageHash,
-		OwnerID:   community.OwnerID.Hex(),
+		ID:      community.ID.Hex(),
+		Name:    community.Name,
+		Image:   community.Image,
+		OwnerID: community.OwnerID.Hex(),
 	}, nil
 }
 
@@ -147,7 +148,7 @@ func (a *API) updateCommunityHandler(r *Request) (interface{}, error) {
 	}
 
 	// Update community
-	err = a.database.CommunityService.UpdateCommunity(r.Context.Request.Context(), communityID, req.Name, req.ImageHash)
+	err = a.database.CommunityService.UpdateCommunity(r.Context.Request.Context(), communityID, req.Name, req.Image)
 	if err != nil {
 		return nil, ErrInternalServerError.WithErr(err)
 	}
@@ -160,10 +161,10 @@ func (a *API) updateCommunityHandler(r *Request) (interface{}, error) {
 
 	// Return response
 	return &CommunityResponse{
-		ID:        updatedCommunity.ID.Hex(),
-		Name:      updatedCommunity.Name,
-		ImageHash: updatedCommunity.ImageHash,
-		OwnerID:   updatedCommunity.OwnerID.Hex(),
+		ID:      updatedCommunity.ID.Hex(),
+		Name:    updatedCommunity.Name,
+		Image:   updatedCommunity.Image,
+		OwnerID: updatedCommunity.OwnerID.Hex(),
 	}, nil
 }
 

--- a/api/communities.go
+++ b/api/communities.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/emprius/emprius-app-backend/types"
+	"time"
 
 	"github.com/emprius/emprius-app-backend/db"
 	"github.com/go-chi/chi/v5"
@@ -39,11 +40,12 @@ type CommunityUserResponse struct {
 
 // CommunityInviteResponse represents a community invitation
 type CommunityInviteResponse struct {
-	ID          string `json:"id"`
-	CommunityID string `json:"communityId"`
-	UserID      string `json:"userId"`
-	InviterID   string `json:"inviterId"`
-	Status      string `json:"status"`
+	ID          string    `json:"id"`
+	CommunityID string    `json:"communityId"`
+	UserID      string    `json:"userId"`
+	InviterID   string    `json:"inviterId"`
+	Status      string    `json:"status"`
+	CreatedAt   time.Time `json:"createdAt"`
 }
 
 // createCommunityHandler handles POST /communities
@@ -378,6 +380,7 @@ func (a *API) getUserPendingInvitesHandler(r *Request) (interface{}, error) {
 			UserID:      invite.UserID.Hex(),
 			InviterID:   invite.InviterID.Hex(),
 			Status:      string(invite.Status),
+			CreatedAt:   invite.CreatedAt,
 		}
 	}
 

--- a/api/communities.go
+++ b/api/communities.go
@@ -297,6 +297,11 @@ func (a *API) inviteUserToCommunityHandler(r *Request) (interface{}, error) {
 		return nil, ErrInvalidUserID.WithErr(err)
 	}
 
+	// Check that user is not inviting themselves
+	if userID == inviterID {
+		return nil, ErrInvalidRequestBodyData.WithErr(fmt.Errorf("users cannot invite themselves to a community"))
+	}
+
 	// Create invitation
 	invite, err := a.database.CommunityService.InviteUserToCommunity(r.Context.Request.Context(), communityID, userID, inviterID)
 	if err != nil {

--- a/api/errors.go
+++ b/api/errors.go
@@ -122,6 +122,10 @@ var (
 		Code:    http.StatusNotFound,
 		Message: "user not found",
 	}
+	ErrCommunityNotFound = &HTTPError{
+		Code:    http.StatusNotFound,
+		Message: "community not found",
+	}
 	ErrInvalidUserID = &HTTPError{
 		Code:    http.StatusBadRequest,
 		Message: "invalid user id format",

--- a/api/errors.go
+++ b/api/errors.go
@@ -134,6 +134,10 @@ var (
 
 // Permission errors
 var (
+	ErrUserNotCommunityMember = &HTTPError{
+		Code:    http.StatusForbidden,
+		Message: "user is not a member of the community this tool belongs to",
+	}
 	ErrToolNotOwnedByUser = &HTTPError{
 		Code:    http.StatusForbidden,
 		Message: "tool not owned by user",

--- a/api/tools.go
+++ b/api/tools.go
@@ -14,6 +14,7 @@ import (
 	"github.com/emprius/emprius-app-backend/types"
 	"github.com/rs/zerolog/log"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -321,9 +322,19 @@ func (a *API) editTool(id int64, newTool *Tool) (int64, error) {
 	return id, nil
 }
 
-func (a *API) toolSearch(query *ToolSearch, userLocation *Location) ([]*Tool, error) {
+func (a *API) toolSearch(query *ToolSearch, userLocation *Location, userID string) ([]*Tool, error) {
 	// Convert user location to GeoJSON format for MongoDB
 	searchLocation := db.NewLocation(userLocation.Latitude, userLocation.Longitude)
+
+	// Convert userID to ObjectID if provided
+	var userObjID *primitive.ObjectID
+	if userID != "" {
+		objID, err := primitive.ObjectIDFromHex(userID)
+		if err != nil {
+			return nil, ErrInvalidUserID.WithErr(err)
+		}
+		userObjID = &objID
+	}
 
 	opts := db.SearchToolsOptions{
 		SearchTerm:       query.SearchTerm,
@@ -333,6 +344,7 @@ func (a *API) toolSearch(query *ToolSearch, userLocation *Location) ([]*Tool, er
 		Distance:         query.Distance,
 		Location:         &searchLocation,
 		TransportOptions: query.TransportOptions,
+		UserID:           userObjID,
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
 	defer cancel()
@@ -502,7 +514,7 @@ func (a *API) toolSearchHandler(r *Request) (interface{}, error) {
 	if err != nil {
 		return nil, ErrUserNotFound.WithErr(err)
 	}
-	tools, err := a.toolSearch(&query, &user.Location)
+	tools, err := a.toolSearch(&query, &user.Location, r.UserID)
 	if err != nil {
 		return nil, err
 	}

--- a/api/tools.go
+++ b/api/tools.go
@@ -620,12 +620,9 @@ func (a *API) editToolHandler(r *Request) (interface{}, error) {
 		return nil, ErrInvalidRequestBodyData.WithErr(err)
 	}
 
-	// Handle communities if provided
-	if len(t.Communities) > 0 {
-		err = a.addToolToCommunity(r.Context.Request.Context(), id, t.Communities)
-		if err != nil {
-			return nil, err
-		}
+	err = a.addToolToCommunity(r.Context.Request.Context(), id, t.Communities)
+	if err != nil {
+		return nil, err
 	}
 
 	newID, err := a.editTool(id, &t)

--- a/api/types.go
+++ b/api/types.go
@@ -80,6 +80,12 @@ type UserProfile struct {
 	Bio            string    `json:"bio,omitempty"`
 }
 
+// UserCommunityInfo represents a user's role in a community
+type UserCommunityInfo struct {
+	ID   string `json:"id"`
+	Role string `json:"role"`
+}
+
 // User represents the user type
 type User struct {
 	ID          string              `json:"id"`
@@ -97,6 +103,7 @@ type User struct {
 	Bio         string              `json:"bio"`
 	RatingCount int                 `json:"ratingCount"`
 	InviteCodes []*SimpleInviteCode `json:"inviteCodes,omitempty"`
+	Communities []UserCommunityInfo `json:"communities,omitempty"`
 }
 
 // SimpleInviteCode represents a simplified invitation code with only essential fields
@@ -149,6 +156,17 @@ func (u *User) FromDBUser(dbu *db.User) *User {
 	u.LastSeen = dbu.LastSeen
 	u.RatingCount = dbu.RatingCount
 
+	// Convert communities
+	if len(dbu.Communities) > 0 {
+		u.Communities = make([]UserCommunityInfo, len(dbu.Communities))
+		for i, comm := range dbu.Communities {
+			u.Communities[i] = UserCommunityInfo{
+				ID:   comm.ID.Hex(),
+				Role: string(comm.Role),
+			}
+		}
+	}
+
 	return u
 }
 
@@ -185,6 +203,7 @@ type Tool struct {
 	Weight           uint32           `json:"weight"`
 	MaxDistance      uint32           `json:"maxDistance"`
 	ReservedDates    []db.DateRange   `json:"reservedDates"`
+	Communities      []string         `json:"communities,omitempty"`
 }
 
 // FromDBTool converts a DB Tool to an API Tool.
@@ -210,6 +229,15 @@ func (t *Tool) FromDBTool(dbt *db.Tool) *Tool {
 	t.Weight = dbt.Weight
 	t.MaxDistance = dbt.MaxDistance
 	t.ReservedDates = dbt.ReservedDates
+
+	// Convert communities
+	if len(dbt.Communities) > 0 {
+		t.Communities = make([]string, len(dbt.Communities))
+		for i, comm := range dbt.Communities {
+			t.Communities[i] = comm.Hex()
+		}
+	}
+
 	return t
 }
 
@@ -230,6 +258,7 @@ type ToolSearch struct {
 	MayBeFree        *bool   `json:"mayBeFree"`
 	AvailableFrom    int     `json:"availableFrom"`
 	TransportOptions []int   `json:"transportOptions"`
+	CommunityID      string  `json:"communityId,omitempty"`
 }
 
 type Info struct {
@@ -299,4 +328,11 @@ func (r *Rating) FromDB(b *db.BookingRating) *Rating {
 	r.ToUserID = b.ToUserID.Hex()
 	r.RatedAt = b.RatedAt.Unix()
 	return r
+}
+
+// PendingActionsResponse represents the response for pending actions
+type PendingActionsResponse struct {
+	PendingRatingsCount  int64 `json:"pendingRatingsCount"`
+	PendingRequestsCount int64 `json:"pendingRequestsCount"`
+	PendingInvitesCount  int64 `json:"pendingInvitesCount"`
 }

--- a/api/types.go
+++ b/api/types.go
@@ -295,6 +295,15 @@ type BookingResponse struct {
 	UpdatedAt int64 `json:"updatedAt"`
 }
 
+// Booking status constants for API
+const (
+	BookingStatusAccepted  = "ACCEPTED"
+	BookingStatusRejected  = "REJECTED"
+	BookingStatusCancelled = "CANCELLED"
+	BookingStatusReturned  = "RETURNED"
+	BookingStatusPending   = "PENDING"
+)
+
 // BookingStatusUpdate represents a request to update a booking's status
 type BookingStatusUpdate struct {
 	Status string `json:"status"`

--- a/api/user.go
+++ b/api/user.go
@@ -155,7 +155,7 @@ func (a *API) usersHandler(r *Request) (interface{}, error) {
 	usernameParam := r.Context.URLParam("username")
 
 	var users []*db.User
-	if usernameParam != nil && len(usernameParam) > 0 {
+	if len(usernameParam) > 0 {
 		// Search by partial name
 		users, err = a.database.UserService.GetUsersByPartialName(r.Context.Request.Context(), usernameParam[0], page)
 	} else {

--- a/db/community.go
+++ b/db/community.go
@@ -301,7 +301,10 @@ func (s *CommunityService) GetUserPendingInvites(ctx context.Context, userID pri
 }
 
 // GetUserPendingInvitesWithDetails retrieves all pending invites for a user with community details
-func (s *CommunityService) GetUserPendingInvitesWithDetails(ctx context.Context, userID primitive.ObjectID) ([]*CommunityInviteWithDetails, error) {
+func (s *CommunityService) GetUserPendingInvitesWithDetails(
+	ctx context.Context,
+	userID primitive.ObjectID,
+) ([]*CommunityInviteWithDetails, error) {
 	pipeline := []bson.M{
 		{
 			"$match": bson.M{
@@ -353,7 +356,10 @@ func (s *CommunityService) GetUserPendingInvitesWithDetails(ctx context.Context,
 }
 
 // GetInviteWithDetails retrieves a single invite with community details
-func (s *CommunityService) GetInviteWithDetails(ctx context.Context, inviteID primitive.ObjectID) (*CommunityInviteWithDetails, error) {
+func (s *CommunityService) GetInviteWithDetails(
+	ctx context.Context,
+	inviteID primitive.ObjectID,
+) (*CommunityInviteWithDetails, error) {
 	pipeline := []bson.M{
 		{
 			"$match": bson.M{
@@ -651,7 +657,10 @@ func (s *CommunityService) GetUserCommunities(ctx context.Context, userID primit
 }
 
 // GetCommunityWithMemberCount retrieves a community by ID with member count and tool count
-func (s *CommunityService) GetCommunityWithMemberCount(ctx context.Context, id primitive.ObjectID) (*Community, int64, int64, error) {
+func (s *CommunityService) GetCommunityWithMemberCount(
+	ctx context.Context,
+	id primitive.ObjectID,
+) (*Community, int64, int64, error) {
 	// Get the community
 	community, err := s.GetCommunity(ctx, id)
 	if err != nil {
@@ -674,7 +683,11 @@ func (s *CommunityService) GetCommunityWithMemberCount(ctx context.Context, id p
 }
 
 // GetUserCommunitiesWithMemberCount retrieves all communities for a specific user with member counts and tool counts
-func (s *CommunityService) GetUserCommunitiesWithMemberCount(ctx context.Context, userID primitive.ObjectID, page int) ([]*Community, map[primitive.ObjectID]int64, map[primitive.ObjectID]int64, error) {
+func (s *CommunityService) GetUserCommunitiesWithMemberCount(
+	ctx context.Context,
+	userID primitive.ObjectID,
+	page int,
+) ([]*Community, map[primitive.ObjectID]int64, map[primitive.ObjectID]int64, error) {
 	// Get the communities
 	communities, err := s.GetUserCommunities(ctx, userID, page)
 	if err != nil {

--- a/db/community.go
+++ b/db/community.go
@@ -68,7 +68,11 @@ func NewCommunityService(db *Database) *CommunityService {
 }
 
 // CreateCommunity creates a new community
-func (s *CommunityService) CreateCommunity(ctx context.Context, name string, imageHash []byte, ownerID primitive.ObjectID) (*Community, error) {
+func (s *CommunityService) CreateCommunity(
+	ctx context.Context,
+	name string, imageHash []byte,
+	ownerID primitive.ObjectID,
+) (*Community, error) {
 	now := time.Now()
 	community := &Community{
 		ID:        primitive.NewObjectID(),
@@ -185,7 +189,12 @@ func (s *CommunityService) GetCommunityUsers(ctx context.Context, communityID pr
 }
 
 // InviteUserToCommunity creates an invitation for a user to join a community
-func (s *CommunityService) InviteUserToCommunity(ctx context.Context, communityID, userID, inviterID primitive.ObjectID) (*CommunityInvite, error) {
+func (s *CommunityService) InviteUserToCommunity(
+	ctx context.Context,
+	communityID,
+	userID,
+	inviterID primitive.ObjectID,
+) (*CommunityInvite, error) {
 	// Check if community exists
 	_, err := s.GetCommunity(ctx, communityID)
 	if err != nil {
@@ -297,7 +306,6 @@ func (s *CommunityService) AcceptInvite(ctx context.Context, inviteID, userID pr
 		"userId": userID,
 		"status": InviteStatusPending,
 	}).Decode(&invite)
-
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
 			return fmt.Errorf("invite not found or not pending")
@@ -328,7 +336,6 @@ func (s *CommunityService) RejectInvite(ctx context.Context, inviteID, userID pr
 		"userId": userID,
 		"status": InviteStatusPending,
 	}).Decode(&invite)
-
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
 			return fmt.Errorf("invite not found or not pending")

--- a/db/community.go
+++ b/db/community.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"github.com/emprius/emprius-app-backend/types"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -24,7 +25,7 @@ const (
 type Community struct {
 	ID        primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
 	Name      string             `bson:"name" json:"name"`
-	ImageHash []byte             `bson:"imageHash,omitempty" json:"imageHash,omitempty"`
+	Image     types.HexBytes     `json:"images"`
 	CreatedAt time.Time          `bson:"createdAt" json:"createdAt"`
 	UpdatedAt time.Time          `bson:"updatedAt" json:"updatedAt"`
 	OwnerID   primitive.ObjectID `bson:"ownerId" json:"ownerId"`
@@ -70,14 +71,14 @@ func NewCommunityService(db *Database) *CommunityService {
 // CreateCommunity creates a new community
 func (s *CommunityService) CreateCommunity(
 	ctx context.Context,
-	name string, imageHash []byte,
+	name string, image types.HexBytes,
 	ownerID primitive.ObjectID,
 ) (*Community, error) {
 	now := time.Now()
 	community := &Community{
 		ID:        primitive.NewObjectID(),
 		Name:      name,
-		ImageHash: imageHash,
+		Image:     image,
 		CreatedAt: now,
 		UpdatedAt: now,
 		OwnerID:   ownerID,
@@ -110,7 +111,7 @@ func (s *CommunityService) GetCommunity(ctx context.Context, id primitive.Object
 }
 
 // UpdateCommunity updates a community
-func (s *CommunityService) UpdateCommunity(ctx context.Context, id primitive.ObjectID, name string, imageHash []byte) error {
+func (s *CommunityService) UpdateCommunity(ctx context.Context, id primitive.ObjectID, name string, image types.HexBytes) error {
 	update := bson.M{
 		"$set": bson.M{
 			"updatedAt": time.Now(),
@@ -121,8 +122,8 @@ func (s *CommunityService) UpdateCommunity(ctx context.Context, id primitive.Obj
 		update["$set"].(bson.M)["name"] = name
 	}
 
-	if imageHash != nil {
-		update["$set"].(bson.M)["imageHash"] = imageHash
+	if image != nil {
+		update["$set"].(bson.M)["image"] = image
 	}
 
 	_, err := s.Collection.UpdateOne(ctx, bson.M{"_id": id}, update)

--- a/db/community.go
+++ b/db/community.go
@@ -1,0 +1,436 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// CommunityRole represents a user's role in a community
+type CommunityRole string
+
+const (
+	CommunityRoleOwner CommunityRole = "owner"
+	CommunityRoleUser  CommunityRole = "user"
+)
+
+// Community represents a group of users that can share tools
+type Community struct {
+	ID        primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
+	Name      string             `bson:"name" json:"name"`
+	ImageHash []byte             `bson:"imageHash,omitempty" json:"imageHash,omitempty"`
+	CreatedAt time.Time          `bson:"createdAt" json:"createdAt"`
+	UpdatedAt time.Time          `bson:"updatedAt" json:"updatedAt"`
+	OwnerID   primitive.ObjectID `bson:"ownerId" json:"ownerId"`
+}
+
+// CommunityInvite represents an invitation to join a community
+type CommunityInvite struct {
+	ID          primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
+	CommunityID primitive.ObjectID `bson:"communityId" json:"communityId"`
+	UserID      primitive.ObjectID `bson:"userId" json:"userId"`
+	InviterID   primitive.ObjectID `bson:"inviterId" json:"inviterId"`
+	CreatedAt   time.Time          `bson:"createdAt" json:"createdAt"`
+	Status      InviteStatus       `bson:"status" json:"status"`
+}
+
+// InviteStatus represents the status of a community invitation
+type InviteStatus string
+
+const (
+	InviteStatusPending  InviteStatus = "pending"
+	InviteStatusAccepted InviteStatus = "accepted"
+	InviteStatusRejected InviteStatus = "rejected"
+)
+
+// CommunityService provides methods to interact with communities
+type CommunityService struct {
+	Collection       *mongo.Collection
+	InviteCollection *mongo.Collection
+	UserService      *UserService
+	ToolService      *ToolService
+}
+
+// NewCommunityService creates a new CommunityService
+func NewCommunityService(db *Database) *CommunityService {
+	return &CommunityService{
+		Collection:       db.Database.Collection("communities"),
+		InviteCollection: db.Database.Collection("community_invites"),
+		UserService:      db.UserService,
+		ToolService:      db.ToolService,
+	}
+}
+
+// CreateCommunity creates a new community
+func (s *CommunityService) CreateCommunity(ctx context.Context, name string, imageHash []byte, ownerID primitive.ObjectID) (*Community, error) {
+	now := time.Now()
+	community := &Community{
+		ID:        primitive.NewObjectID(),
+		Name:      name,
+		ImageHash: imageHash,
+		CreatedAt: now,
+		UpdatedAt: now,
+		OwnerID:   ownerID,
+	}
+
+	_, err := s.Collection.InsertOne(ctx, community)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add owner to community
+	err = s.UserService.AddUserToCommunity(ctx, ownerID, community.ID, CommunityRoleOwner)
+	if err != nil {
+		// Rollback community creation if we can't add the owner
+		_ = s.DeleteCommunity(ctx, community.ID)
+		return nil, err
+	}
+
+	return community, nil
+}
+
+// GetCommunity retrieves a community by ID
+func (s *CommunityService) GetCommunity(ctx context.Context, id primitive.ObjectID) (*Community, error) {
+	var community Community
+	err := s.Collection.FindOne(ctx, bson.M{"_id": id}).Decode(&community)
+	if err != nil {
+		return nil, err
+	}
+	return &community, nil
+}
+
+// UpdateCommunity updates a community
+func (s *CommunityService) UpdateCommunity(ctx context.Context, id primitive.ObjectID, name string, imageHash []byte) error {
+	update := bson.M{
+		"$set": bson.M{
+			"updatedAt": time.Now(),
+		},
+	}
+
+	if name != "" {
+		update["$set"].(bson.M)["name"] = name
+	}
+
+	if imageHash != nil {
+		update["$set"].(bson.M)["imageHash"] = imageHash
+	}
+
+	_, err := s.Collection.UpdateOne(ctx, bson.M{"_id": id}, update)
+	return err
+}
+
+// DeleteCommunity deletes a community
+func (s *CommunityService) DeleteCommunity(ctx context.Context, id primitive.ObjectID) error {
+	// Get all users in the community
+	users, err := s.GetCommunityUsers(ctx, id, 0)
+	if err != nil {
+		return err
+	}
+
+	// Remove community from all users
+	for _, user := range users {
+		err = s.UserService.RemoveUserFromCommunity(ctx, user.ID, id)
+		if err != nil {
+			log.Error().Err(err).Str("userId", user.ID.Hex()).Str("communityId", id.Hex()).Msg("Failed to remove user from community")
+		}
+	}
+
+	// Delete all invites for this community
+	_, err = s.InviteCollection.DeleteMany(ctx, bson.M{"communityId": id})
+	if err != nil {
+		log.Error().Err(err).Str("communityId", id.Hex()).Msg("Failed to delete community invites")
+	}
+
+	// Delete the community
+	_, err = s.Collection.DeleteOne(ctx, bson.M{"_id": id})
+	return err
+}
+
+// GetCommunityUsers retrieves all users in a community
+func (s *CommunityService) GetCommunityUsers(ctx context.Context, communityID primitive.ObjectID, page int) ([]*User, error) {
+	if page < 0 {
+		page = 0
+	}
+
+	skip := page * defaultPageSize
+
+	// Find users with this community in their communities array
+	filter := bson.M{"communities.id": communityID}
+	opts := options.Find().
+		SetSort(bson.D{{Key: "name", Value: 1}}). // Sort by name
+		SetSkip(int64(skip)).
+		SetLimit(int64(defaultPageSize))
+
+	cursor, err := s.UserService.Collection.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := cursor.Close(ctx); err != nil {
+			log.Error().Err(err).Msg("Error closing cursor")
+		}
+	}()
+
+	var users []*User
+	if err := cursor.All(ctx, &users); err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+// InviteUserToCommunity creates an invitation for a user to join a community
+func (s *CommunityService) InviteUserToCommunity(ctx context.Context, communityID, userID, inviterID primitive.ObjectID) (*CommunityInvite, error) {
+	// Check if community exists
+	_, err := s.GetCommunity(ctx, communityID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if user exists
+	_, err = s.UserService.GetUserByID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if inviter is in the community
+	inviter, err := s.UserService.GetUserByID(ctx, inviterID)
+	if err != nil {
+		return nil, err
+	}
+
+	var isMember bool
+	for _, comm := range inviter.Communities {
+		if comm.ID == communityID {
+			isMember = true
+			break
+		}
+	}
+
+	if !isMember {
+		return nil, fmt.Errorf("inviter is not a member of the community")
+	}
+
+	// Check if invitation already exists
+	var existingInvite CommunityInvite
+	err = s.InviteCollection.FindOne(ctx, bson.M{
+		"communityId": communityID,
+		"userId":      userID,
+		"status":      InviteStatusPending,
+	}).Decode(&existingInvite)
+
+	if err == nil {
+		// Invitation already exists
+		return &existingInvite, nil
+	} else if err != mongo.ErrNoDocuments {
+		// Some other error occurred
+		return nil, err
+	}
+
+	// Create new invitation
+	invite := &CommunityInvite{
+		ID:          primitive.NewObjectID(),
+		CommunityID: communityID,
+		UserID:      userID,
+		InviterID:   inviterID,
+		CreatedAt:   time.Now(),
+		Status:      InviteStatusPending,
+	}
+
+	_, err = s.InviteCollection.InsertOne(ctx, invite)
+	if err != nil {
+		return nil, err
+	}
+
+	return invite, nil
+}
+
+// GetUserPendingInvites retrieves all pending invites for a user
+func (s *CommunityService) GetUserPendingInvites(ctx context.Context, userID primitive.ObjectID) ([]*CommunityInvite, error) {
+	filter := bson.M{
+		"userId": userID,
+		"status": InviteStatusPending,
+	}
+
+	cursor, err := s.InviteCollection.Find(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := cursor.Close(ctx); err != nil {
+			log.Error().Err(err).Msg("Error closing cursor")
+		}
+	}()
+
+	var invites []*CommunityInvite
+	if err := cursor.All(ctx, &invites); err != nil {
+		return nil, err
+	}
+	return invites, nil
+}
+
+// CountUserPendingInvites counts the number of pending invites for a user
+func (s *CommunityService) CountUserPendingInvites(ctx context.Context, userID primitive.ObjectID) (int64, error) {
+	filter := bson.M{
+		"userId": userID,
+		"status": InviteStatusPending,
+	}
+
+	count, err := s.InviteCollection.CountDocuments(ctx, filter)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// AcceptInvite accepts a community invitation
+func (s *CommunityService) AcceptInvite(ctx context.Context, inviteID, userID primitive.ObjectID) error {
+	// Get the invite
+	var invite CommunityInvite
+	err := s.InviteCollection.FindOne(ctx, bson.M{
+		"_id":    inviteID,
+		"userId": userID,
+		"status": InviteStatusPending,
+	}).Decode(&invite)
+
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return fmt.Errorf("invite not found or not pending")
+		}
+		return err
+	}
+
+	// Update invite status
+	_, err = s.InviteCollection.UpdateOne(
+		ctx,
+		bson.M{"_id": inviteID},
+		bson.M{"$set": bson.M{"status": InviteStatusAccepted}},
+	)
+	if err != nil {
+		return err
+	}
+
+	// Add user to community
+	return s.UserService.AddUserToCommunity(ctx, userID, invite.CommunityID, CommunityRoleUser)
+}
+
+// RejectInvite rejects a community invitation
+func (s *CommunityService) RejectInvite(ctx context.Context, inviteID, userID primitive.ObjectID) error {
+	// Get the invite
+	var invite CommunityInvite
+	err := s.InviteCollection.FindOne(ctx, bson.M{
+		"_id":    inviteID,
+		"userId": userID,
+		"status": InviteStatusPending,
+	}).Decode(&invite)
+
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return fmt.Errorf("invite not found or not pending")
+		}
+		return err
+	}
+
+	// Update invite status
+	_, err = s.InviteCollection.UpdateOne(
+		ctx,
+		bson.M{"_id": inviteID},
+		bson.M{"$set": bson.M{"status": InviteStatusRejected}},
+	)
+	return err
+}
+
+// LeaveCommunity removes a user from a community
+func (s *CommunityService) LeaveCommunity(ctx context.Context, communityID, userID primitive.ObjectID) error {
+	// Get the community
+	community, err := s.GetCommunity(ctx, communityID)
+	if err != nil {
+		return err
+	}
+
+	// Check if user is the owner
+	if community.OwnerID == userID {
+		return fmt.Errorf("community owner cannot leave the community")
+	}
+
+	// Remove user from community
+	return s.UserService.RemoveUserFromCommunity(ctx, userID, communityID)
+}
+
+// AddToolToCommunity adds a tool to a community
+func (s *CommunityService) AddToolToCommunity(ctx context.Context, toolID int64, communityID primitive.ObjectID) error {
+	// Get the tool
+	tool, err := s.ToolService.GetToolByID(ctx, toolID)
+	if err != nil {
+		return err
+	}
+
+	// Check if tool already has this community
+	for _, comm := range tool.Communities {
+		if comm == communityID {
+			return nil // Tool already in this community
+		}
+	}
+
+	// Add community to tool's communities
+	_, err = s.ToolService.Collection.UpdateOne(
+		ctx,
+		bson.M{"_id": toolID},
+		bson.M{
+			"$push": bson.M{
+				"communities": communityID,
+			},
+		},
+	)
+	return err
+}
+
+// RemoveToolFromCommunity removes a tool from a community
+func (s *CommunityService) RemoveToolFromCommunity(ctx context.Context, toolID int64, communityID primitive.ObjectID) error {
+	// Remove community from tool's communities
+	_, err := s.ToolService.Collection.UpdateOne(
+		ctx,
+		bson.M{"_id": toolID},
+		bson.M{
+			"$pull": bson.M{
+				"communities": communityID,
+			},
+		},
+	)
+	return err
+}
+
+// GetCommunityTools retrieves all tools in a community
+func (s *CommunityService) GetCommunityTools(ctx context.Context, communityID primitive.ObjectID) ([]*Tool, error) {
+	// Find tools with this community in their communities array
+	filter := bson.M{"communities": communityID}
+	cursor, err := s.ToolService.Collection.Find(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := cursor.Close(ctx); err != nil {
+			log.Error().Err(err).Msg("Error closing cursor")
+		}
+	}()
+
+	var tools []*Tool
+	if err := cursor.All(ctx, &tools); err != nil {
+		return nil, err
+	}
+	return tools, nil
+}
+
+// CommunityExists checks if a community exists
+func (s *CommunityService) CommunityExists(ctx context.Context, communityID primitive.ObjectID) (bool, error) {
+	count, err := s.Collection.CountDocuments(ctx, bson.M{"_id": communityID})
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}

--- a/db/community.go
+++ b/db/community.go
@@ -45,9 +45,9 @@ type CommunityInvite struct {
 type InviteStatus string
 
 const (
-	InviteStatusPending  InviteStatus = "pending"
-	InviteStatusAccepted InviteStatus = "accepted"
-	InviteStatusRejected InviteStatus = "rejected"
+	InviteStatusPending  InviteStatus = "PENDING"
+	InviteStatusAccepted InviteStatus = "ACCEPTED"
+	InviteStatusRejected InviteStatus = "REJECTED"
 )
 
 // CommunityService provides methods to interact with communities

--- a/db/community_test.go
+++ b/db/community_test.go
@@ -11,6 +11,13 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+const (
+	testOwnerName  = "test-owner"
+	testOwnerEmail = "test-owner@example.com"
+	testToolTitle  = "Test Tool"
+	testToolDesc   = "A tool for testing"
+)
+
 func TestCountCommunityTools(t *testing.T) {
 	ctx := context.Background()
 
@@ -44,8 +51,8 @@ func TestCountCommunityTools(t *testing.T) {
 	// Create a test user (owner)
 	var owner1 User
 	owner1.ID = primitive.NewObjectID()
-	owner1.Name = "test-owner"
-	owner1.Email = "test-owner@example.com"
+	owner1.Name = testOwnerName
+	owner1.Email = testOwnerEmail
 	_, err = db.UserService.Collection.InsertOne(ctx, &owner1)
 	if err != nil {
 		t.Fatalf("Failed to create test user: %v", err)
@@ -69,8 +76,8 @@ func TestCountCommunityTools(t *testing.T) {
 	// Create a test tool
 	var tool Tool
 	tool.ID = 1
-	tool.Title = "Test Tool"
-	tool.Description = "A tool for testing"
+	tool.Title = testToolTitle
+	tool.Description = testToolDesc
 	tool.UserID = owner1.ID
 	tool.Communities = []primitive.ObjectID{}
 	_, err = db.ToolService.Collection.InsertOne(ctx, &tool)
@@ -169,8 +176,8 @@ func TestGetCommunityWithMemberCount(t *testing.T) {
 	// Create a test user (owner)
 	var owner2 User
 	owner2.ID = primitive.NewObjectID()
-	owner2.Name = "test-owner"
-	owner2.Email = "test-owner@example.com"
+	owner2.Name = testOwnerName
+	owner2.Email = testOwnerEmail
 	_, err = db.UserService.Collection.InsertOne(ctx, &owner2)
 	if err != nil {
 		t.Fatalf("Failed to create test user: %v", err)
@@ -209,8 +216,8 @@ func TestGetCommunityWithMemberCount(t *testing.T) {
 	// Create a test tool
 	var tool Tool
 	tool.ID = 1
-	tool.Title = "Test Tool"
-	tool.Description = "A tool for testing"
+	tool.Title = testToolTitle
+	tool.Description = testToolDesc
 	tool.UserID = owner2.ID
 	tool.Communities = []primitive.ObjectID{}
 	_, err = db.ToolService.Collection.InsertOne(ctx, &tool)
@@ -225,7 +232,7 @@ func TestGetCommunityWithMemberCount(t *testing.T) {
 	}
 
 	// Get community with member count and tool count again
-	comm, membersCount, toolsCount, err = db.CommunityService.GetCommunityWithMemberCount(ctx, community.ID)
+	_, _, toolsCount, err = db.CommunityService.GetCommunityWithMemberCount(ctx, community.ID)
 	if err != nil {
 		t.Fatalf("Failed to get community with member count: %v", err)
 	}
@@ -269,8 +276,8 @@ func TestGetUserCommunitiesWithMemberCount(t *testing.T) {
 	// Create a test user (owner)
 	var owner3 User
 	owner3.ID = primitive.NewObjectID()
-	owner3.Name = "test-owner"
-	owner3.Email = "test-owner@example.com"
+	owner3.Name = testOwnerName
+	owner3.Email = testOwnerEmail
 	_, err = db.UserService.Collection.InsertOne(ctx, &owner3)
 	if err != nil {
 		t.Fatalf("Failed to create test user: %v", err)
@@ -312,8 +319,8 @@ func TestGetUserCommunitiesWithMemberCount(t *testing.T) {
 	// Create a test tool
 	var tool Tool
 	tool.ID = 1
-	tool.Title = "Test Tool"
-	tool.Description = "A tool for testing"
+	tool.Title = testToolTitle
+	tool.Description = testToolDesc
 	tool.UserID = owner3.ID
 	tool.Communities = []primitive.ObjectID{}
 	_, err = db.ToolService.Collection.InsertOne(ctx, &tool)
@@ -328,7 +335,7 @@ func TestGetUserCommunitiesWithMemberCount(t *testing.T) {
 	}
 
 	// Get user communities with member count and tool count again
-	communities, memberCounts, toolCounts, err = db.CommunityService.GetUserCommunitiesWithMemberCount(ctx, owner3.ID, 0)
+	_, _, toolCounts, err = db.CommunityService.GetUserCommunitiesWithMemberCount(ctx, owner3.ID, 0)
 	if err != nil {
 		t.Fatalf("Failed to get user communities with member count: %v", err)
 	}

--- a/db/community_test.go
+++ b/db/community_test.go
@@ -1,0 +1,340 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/emprius/emprius-app-backend/types"
+	qt "github.com/frankban/quicktest"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func TestCountCommunityTools(t *testing.T) {
+	ctx := context.Background()
+
+	// Start MongoDB container
+	container, err := StartMongoContainer(ctx)
+	qt.Assert(t, err, qt.IsNil, qt.Commentf("Failed to start MongoDB container"))
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	// Get MongoDB connection string
+	mongoURI, err := container.Endpoint(ctx, "mongodb")
+	qt.Assert(t, err, qt.IsNil, qt.Commentf("Failed to get MongoDB connection string"))
+
+	// Create a MongoDB client
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI))
+	qt.Assert(t, err, qt.IsNil, qt.Commentf("Failed to create MongoDB client"))
+	defer func() { _ = client.Disconnect(ctx) }()
+
+	// Use a random database name for isolation
+	dbName := RandomDatabaseName()
+	database := client.Database(dbName)
+
+	// Initialize Database with all services
+	db := &Database{
+		Client:   client,
+		Database: database,
+	}
+	db.UserService = NewUserService(db)
+	db.ToolService = NewToolService(db)
+	db.CommunityService = NewCommunityService(db)
+
+	// Create a test user (owner)
+	var owner1 User
+	owner1.ID = primitive.NewObjectID()
+	owner1.Name = "test-owner"
+	owner1.Email = "test-owner@example.com"
+	_, err = db.UserService.Collection.InsertOne(ctx, &owner1)
+	if err != nil {
+		t.Fatalf("Failed to create test user: %v", err)
+	}
+
+	// Create a test community
+	community, err := db.CommunityService.CreateCommunity(ctx, "Test Community", types.HexBytes{}, owner1.ID)
+	if err != nil {
+		t.Fatalf("Failed to create test community: %v", err)
+	}
+
+	// Initially, there should be no tools in the community
+	count, err := db.CommunityService.CountCommunityTools(ctx, community.ID)
+	if err != nil {
+		t.Fatalf("Failed to count community tools: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("Expected 0 tools, got %d", count)
+	}
+
+	// Create a test tool
+	var tool Tool
+	tool.ID = 1
+	tool.Title = "Test Tool"
+	tool.Description = "A tool for testing"
+	tool.UserID = owner1.ID
+	tool.Communities = []primitive.ObjectID{}
+	_, err = db.ToolService.Collection.InsertOne(ctx, &tool)
+	if err != nil {
+		t.Fatalf("Failed to create test tool: %v", err)
+	}
+
+	// Add the tool to the community
+	err = db.CommunityService.AddToolToCommunity(ctx, tool.ID, community.ID)
+	if err != nil {
+		t.Fatalf("Failed to add tool to community: %v", err)
+	}
+
+	// Now there should be 1 tool in the community
+	count, err = db.CommunityService.CountCommunityTools(ctx, community.ID)
+	if err != nil {
+		t.Fatalf("Failed to count community tools: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("Expected 1 tool, got %d", count)
+	}
+
+	// Create another test tool
+	var tool2 Tool
+	tool2.ID = 2
+	tool2.Title = "Another Test Tool"
+	tool2.Description = "Another tool for testing"
+	tool2.UserID = owner1.ID
+	tool2.Communities = []primitive.ObjectID{}
+	_, err = db.ToolService.Collection.InsertOne(ctx, &tool2)
+	if err != nil {
+		t.Fatalf("Failed to create second test tool: %v", err)
+	}
+
+	// Add the second tool to the community
+	err = db.CommunityService.AddToolToCommunity(ctx, tool2.ID, community.ID)
+	if err != nil {
+		t.Fatalf("Failed to add second tool to community: %v", err)
+	}
+
+	// Now there should be 2 tools in the community
+	count, err = db.CommunityService.CountCommunityTools(ctx, community.ID)
+	if err != nil {
+		t.Fatalf("Failed to count community tools: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("Expected 2 tools, got %d", count)
+	}
+
+	// Remove a tool from the community
+	err = db.CommunityService.RemoveToolFromCommunity(ctx, tool.ID, community.ID)
+	if err != nil {
+		t.Fatalf("Failed to remove tool from community: %v", err)
+	}
+
+	// Now there should be 1 tool in the community
+	count, err = db.CommunityService.CountCommunityTools(ctx, community.ID)
+	if err != nil {
+		t.Fatalf("Failed to count community tools: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("Expected 1 tool, got %d", count)
+	}
+}
+
+func TestGetCommunityWithMemberCount(t *testing.T) {
+	ctx := context.Background()
+
+	// Start MongoDB container
+	container, err := StartMongoContainer(ctx)
+	qt.Assert(t, err, qt.IsNil, qt.Commentf("Failed to start MongoDB container"))
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	// Get MongoDB connection string
+	mongoURI, err := container.Endpoint(ctx, "mongodb")
+	qt.Assert(t, err, qt.IsNil, qt.Commentf("Failed to get MongoDB connection string"))
+
+	// Create a MongoDB client
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI))
+	qt.Assert(t, err, qt.IsNil, qt.Commentf("Failed to create MongoDB client"))
+	defer func() { _ = client.Disconnect(ctx) }()
+
+	// Use a random database name for isolation
+	dbName := RandomDatabaseName()
+	database := client.Database(dbName)
+
+	// Initialize Database with all services
+	db := &Database{
+		Client:   client,
+		Database: database,
+	}
+	db.UserService = NewUserService(db)
+	db.ToolService = NewToolService(db)
+	db.CommunityService = NewCommunityService(db)
+
+	// Create a test user (owner)
+	var owner2 User
+	owner2.ID = primitive.NewObjectID()
+	owner2.Name = "test-owner"
+	owner2.Email = "test-owner@example.com"
+	_, err = db.UserService.Collection.InsertOne(ctx, &owner2)
+	if err != nil {
+		t.Fatalf("Failed to create test user: %v", err)
+	}
+
+	// Create a test community
+	community, err := db.CommunityService.CreateCommunity(ctx, "Test Community", types.HexBytes{}, owner2.ID)
+	if err != nil {
+		t.Fatalf("Failed to create test community: %v", err)
+	}
+
+	// Get community with member count and tool count
+	comm, membersCount, toolsCount, err := db.CommunityService.GetCommunityWithMemberCount(ctx, community.ID)
+	if err != nil {
+		t.Fatalf("Failed to get community with member count: %v", err)
+	}
+
+	// Verify the community data
+	if comm.ID != community.ID {
+		t.Errorf("Expected community ID %s, got %s", community.ID.Hex(), comm.ID.Hex())
+	}
+	if comm.Name != "Test Community" {
+		t.Errorf("Expected community name 'Test Community', got '%s'", comm.Name)
+	}
+
+	// Verify the member count (should be 1 - just the owner)
+	if membersCount != 1 {
+		t.Errorf("Expected 1 member, got %d", membersCount)
+	}
+
+	// Verify the tool count (should be 0 initially)
+	if toolsCount != 0 {
+		t.Errorf("Expected 0 tools, got %d", toolsCount)
+	}
+
+	// Create a test tool
+	var tool Tool
+	tool.ID = 1
+	tool.Title = "Test Tool"
+	tool.Description = "A tool for testing"
+	tool.UserID = owner2.ID
+	tool.Communities = []primitive.ObjectID{}
+	_, err = db.ToolService.Collection.InsertOne(ctx, &tool)
+	if err != nil {
+		t.Fatalf("Failed to create test tool: %v", err)
+	}
+
+	// Add the tool to the community
+	err = db.CommunityService.AddToolToCommunity(ctx, tool.ID, community.ID)
+	if err != nil {
+		t.Fatalf("Failed to add tool to community: %v", err)
+	}
+
+	// Get community with member count and tool count again
+	comm, membersCount, toolsCount, err = db.CommunityService.GetCommunityWithMemberCount(ctx, community.ID)
+	if err != nil {
+		t.Fatalf("Failed to get community with member count: %v", err)
+	}
+
+	// Verify the tool count (should be 1 now)
+	if toolsCount != 1 {
+		t.Errorf("Expected 1 tool, got %d", toolsCount)
+	}
+}
+
+func TestGetUserCommunitiesWithMemberCount(t *testing.T) {
+	ctx := context.Background()
+
+	// Start MongoDB container
+	container, err := StartMongoContainer(ctx)
+	qt.Assert(t, err, qt.IsNil, qt.Commentf("Failed to start MongoDB container"))
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	// Get MongoDB connection string
+	mongoURI, err := container.Endpoint(ctx, "mongodb")
+	qt.Assert(t, err, qt.IsNil, qt.Commentf("Failed to get MongoDB connection string"))
+
+	// Create a MongoDB client
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI))
+	qt.Assert(t, err, qt.IsNil, qt.Commentf("Failed to create MongoDB client"))
+	defer func() { _ = client.Disconnect(ctx) }()
+
+	// Use a random database name for isolation
+	dbName := RandomDatabaseName()
+	database := client.Database(dbName)
+
+	// Initialize Database with all services
+	db := &Database{
+		Client:   client,
+		Database: database,
+	}
+	db.UserService = NewUserService(db)
+	db.ToolService = NewToolService(db)
+	db.CommunityService = NewCommunityService(db)
+
+	// Create a test user (owner)
+	var owner3 User
+	owner3.ID = primitive.NewObjectID()
+	owner3.Name = "test-owner"
+	owner3.Email = "test-owner@example.com"
+	_, err = db.UserService.Collection.InsertOne(ctx, &owner3)
+	if err != nil {
+		t.Fatalf("Failed to create test user: %v", err)
+	}
+
+	// Create a test community
+	community, err := db.CommunityService.CreateCommunity(ctx, "Test Community", types.HexBytes{}, owner3.ID)
+	if err != nil {
+		t.Fatalf("Failed to create test community: %v", err)
+	}
+
+	// Get user communities with member count and tool count
+	communities, memberCounts, toolCounts, err := db.CommunityService.GetUserCommunitiesWithMemberCount(ctx, owner3.ID, 0)
+	if err != nil {
+		t.Fatalf("Failed to get user communities with member count: %v", err)
+	}
+
+	// Verify the communities data
+	if len(communities) != 1 {
+		t.Fatalf("Expected 1 community, got %d", len(communities))
+	}
+	if communities[0].ID != community.ID {
+		t.Errorf("Expected community ID %s, got %s", community.ID.Hex(), communities[0].ID.Hex())
+	}
+	if communities[0].Name != "Test Community" {
+		t.Errorf("Expected community name 'Test Community', got '%s'", communities[0].Name)
+	}
+
+	// Verify the member count (should be 1 - just the owner)
+	if memberCounts[community.ID] != 1 {
+		t.Errorf("Expected 1 member, got %d", memberCounts[community.ID])
+	}
+
+	// Verify the tool count (should be 0 initially)
+	if toolCounts[community.ID] != 0 {
+		t.Errorf("Expected 0 tools, got %d", toolCounts[community.ID])
+	}
+
+	// Create a test tool
+	var tool Tool
+	tool.ID = 1
+	tool.Title = "Test Tool"
+	tool.Description = "A tool for testing"
+	tool.UserID = owner3.ID
+	tool.Communities = []primitive.ObjectID{}
+	_, err = db.ToolService.Collection.InsertOne(ctx, &tool)
+	if err != nil {
+		t.Fatalf("Failed to create test tool: %v", err)
+	}
+
+	// Add the tool to the community
+	err = db.CommunityService.AddToolToCommunity(ctx, tool.ID, community.ID)
+	if err != nil {
+		t.Fatalf("Failed to add tool to community: %v", err)
+	}
+
+	// Get user communities with member count and tool count again
+	communities, memberCounts, toolCounts, err = db.CommunityService.GetUserCommunitiesWithMemberCount(ctx, owner3.ID, 0)
+	if err != nil {
+		t.Fatalf("Failed to get user communities with member count: %v", err)
+	}
+
+	// Verify the tool count (should be 1 now)
+	if toolCounts[community.ID] != 1 {
+		t.Errorf("Expected 1 tool, got %d", toolCounts[community.ID])
+	}
+}

--- a/db/init.go
+++ b/db/init.go
@@ -193,6 +193,76 @@ func createUniqueIndexes(db *Database, ctx context.Context) error {
 		return err
 	}
 
+	// Community collection indexes
+	communityColl := db.Database.Collection("communities")
+	_, err = communityColl.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "name", Value: 1}},
+			Options: options.Index(),
+		},
+		{
+			Keys:    bson.D{{Key: "createdAt", Value: 1}},
+			Options: options.Index(),
+		},
+	})
+	if err != nil {
+		log.Printf("Error creating community indexes: %v\n", err)
+		return err
+	}
+
+	// Community member collection indexes
+	communityMemberColl := db.Database.Collection("community_members")
+	_, err = communityMemberColl.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys: bson.D{
+				{Key: "communityId", Value: 1},
+				{Key: "userId", Value: 1},
+			},
+			Options: options.Index().SetUnique(true),
+		},
+		{
+			Keys:    bson.D{{Key: "userId", Value: 1}},
+			Options: options.Index(),
+		},
+		{
+			Keys:    bson.D{{Key: "communityId", Value: 1}},
+			Options: options.Index(),
+		},
+	})
+	if err != nil {
+		log.Printf("Error creating community member indexes: %v\n", err)
+		return err
+	}
+
+	// Community invite collection indexes
+	communityInviteColl := db.Database.Collection("community_invites")
+	_, err = communityInviteColl.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys: bson.D{
+				{Key: "communityId", Value: 1},
+				{Key: "toUserId", Value: 1},
+				{Key: "status", Value: 1},
+			},
+			Options: options.Index(),
+		},
+		{
+			Keys:    bson.D{{Key: "toUserId", Value: 1}},
+			Options: options.Index(),
+		},
+		{
+			Keys:    bson.D{{Key: "fromUserId", Value: 1}},
+			Options: options.Index(),
+		},
+		{
+			Keys:    bson.D{{Key: "createdAt", Value: 1}},
+			Options: options.Index(),
+		},
+	})
+	if err != nil {
+		log.Printf("Error creating community invite indexes: %v\n", err)
+		return err
+	}
+
 	log.Println("All indexes created successfully")
 	return nil
 }

--- a/db/mongo.go
+++ b/db/mongo.go
@@ -24,6 +24,7 @@ type Database struct {
 	UserService         *UserService
 	BookingService      *BookingService
 	InviteCodeService   *InviteCodeService
+	CommunityService    *CommunityService
 }
 
 // New initializes a new MongoDB connection.
@@ -53,6 +54,7 @@ func New(uri string) (*Database, error) {
 	database.UserService = NewUserService(database)
 	database.BookingService = NewBookingService(database.Database)
 	database.InviteCodeService = NewInviteCodeService(database)
+	database.CommunityService = NewCommunityService(database)
 	return database, nil
 }
 

--- a/db/tool.go
+++ b/db/tool.go
@@ -352,7 +352,10 @@ func (s *ToolService) SearchTools(ctx context.Context, opts SearchToolsOptions) 
 // It returns only tools that either:
 // 1. Don't belong to any community, or
 // 2. Belong to at least one community where the user is a member
-func (s *ToolService) filterToolsByCommunityMembership(ctx context.Context, tools []*Tool, userID primitive.ObjectID) ([]*Tool, error) {
+func (s *ToolService) filterToolsByCommunityMembership(
+	ctx context.Context, tools []*Tool,
+	userID primitive.ObjectID,
+) ([]*Tool, error) {
 	// Get the user to check their communities
 	userService := NewUserService(&Database{Database: s.Collection.Database()})
 	userCommunities, err := userService.GetUserCommunities(ctx, userID)

--- a/db/user.go
+++ b/db/user.go
@@ -244,7 +244,11 @@ func (s *UserService) RemoveUserFromCommunity(ctx context.Context, userID, commu
 }
 
 // UpdateUserCommunityRole updates a user's role in a community
-func (s *UserService) UpdateUserCommunityRole(ctx context.Context, userID, communityID primitive.ObjectID, role CommunityRole) error {
+func (s *UserService) UpdateUserCommunityRole(
+	ctx context.Context, userID,
+	communityID primitive.ObjectID,
+	role CommunityRole,
+) error {
 	_, err := s.Collection.UpdateOne(
 		ctx,
 		bson.M{

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -17,6 +17,8 @@ tags:
     description: Tool management and search operations
   - name: Bookings
     description: Booking management and rating operations
+  - name: Communities
+    description: Community management and member operations
 
 servers:
   - url: http://localhost:8080
@@ -113,6 +115,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/DateRange'
+        communities:
+          type: array
+          items:
+            type: string
+          nullable: true
+          description: List of communities ids where the user belongs to
 
     UserProfile:
       type: object
@@ -152,7 +160,12 @@ components:
         ratingCount:
           type: integer
           description: "Number of ratings received by the user"
-
+        communities:
+          type: array
+          items:
+            type: string
+          nullable: true
+          description: List of communities ids where the user belongs to
     LoginRequest:
       type: object
       required:
@@ -345,6 +358,100 @@ components:
         requester:
           $ref: '#/components/schemas/RatingParty'
           description: Rating information for the requester
+
+    Community:
+      type: object
+      properties:
+        id:
+          type: string
+          format: objectid
+          description: MongoDB ObjectID of the community
+        name:
+          type: string
+          description: Name of the community
+        description:
+          type: string
+          description: Description of the community
+        location:
+          $ref: '#/components/schemas/Location'
+          description: Geographic location of the community
+        createdBy:
+          type: string
+          format: objectid
+          description: MongoDB ObjectID of the user who created the community
+        createdAt:
+          type: string
+          format: date-time
+          description: When the community was created
+        updatedAt:
+          type: string
+          format: date-time
+          description: When the community was last updated
+        image:
+          type: string
+          description: Image hash representing the community
+
+    CommunityMember:
+      type: object
+      properties:
+        userId:
+          type: string
+          format: objectid
+          description: MongoDB ObjectID of the user
+        communityId:
+          type: string
+          format: objectid
+          description: MongoDB ObjectID of the community
+        role:
+          type: string
+          enum: [ADMIN, MEMBER]
+          description: Role of the user in the community
+        joinedAt:
+          type: string
+          format: date-time
+          description: When the user joined the community
+
+    CommunityInvite:
+      type: object
+      properties:
+        id:
+          type: string
+          format: objectid
+          description: MongoDB ObjectID of the invite
+        communityId:
+          type: string
+          format: objectid
+          description: MongoDB ObjectID of the community
+        userId:
+          type: string
+          format: objectid
+          description: MongoDB ObjectID of the invited user
+        invitedBy:
+          type: string
+          format: objectid
+          description: MongoDB ObjectID of the user who sent the invite
+        status:
+          type: string
+          enum: [PENDING, ACCEPTED, REJECTED]
+          description: Status of the invite
+        createdAt:
+          type: string
+          format: date-time
+          description: When the invite was created
+        updatedAt:
+          type: string
+          format: date-time
+          description: When the invite was last updated
+
+    InviteStatusUpdate:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum: [ACCEPTED, REJECTED]
+          description: New status for the invite
 
     BookingStatusUpdate:
       type: object
@@ -671,6 +778,10 @@ paths:
                         type: integer
                         format: int64
                         description: Number of pending booking requests
+                      pendingInvitesCount:
+                        type: integer
+                        format: int64
+                        description: Number of pending community invites
         '401':
           description: Unauthorized
         '500':
@@ -1111,3 +1222,294 @@ paths:
         '500':
           description: Internal server error
 
+  /communities:
+    post:
+      tags:
+        - Communities
+      summary: Create a new community
+      description: Create a new community with the authenticated user as admin
+      security:
+        - bearerAuth: [ ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Community'
+      responses:
+        '201':
+          description: Community created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Community'
+        '400':
+          description: Invalid request body
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal server error
+
+  /communities/{communityId}:
+    get:
+      tags:
+        - Communities
+      summary: Get community by ID
+      description: Get details of a specific community
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - name: communityId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: objectid
+            description: MongoDB ObjectID of the community
+      responses:
+        '200':
+          description: Community details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Community'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Community not found
+        '500':
+          description: Internal server error
+    put:
+      tags:
+        - Communities
+      summary: Update community
+      description: Update a community's details (admin only)
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - name: communityId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: objectid
+            description: MongoDB ObjectID of the community
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Community'
+      responses:
+        '200':
+          description: Community updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Community'
+        '400':
+          description: Invalid request body
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - User is not an admin of this community
+        '404':
+          description: Community not found
+        '500':
+          description: Internal server error
+    delete:
+      tags:
+        - Communities
+      summary: Delete community
+      description: Delete a community (admin only)
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - name: communityId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: objectid
+            description: MongoDB ObjectID of the community
+      responses:
+        '204':
+          description: Community deleted successfully
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - User is not an admin of this community
+        '404':
+          description: Community not found
+        '500':
+          description: Internal server error
+
+  /communities/{communityId}/users:
+    get:
+      tags:
+        - Communities
+      summary: Get community members
+      description: Get all users who are members of a specific community
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - name: communityId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: objectid
+            description: MongoDB ObjectID of the community
+      responses:
+        '200':
+          description: List of community members
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserProfile'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Community not found
+        '500':
+          description: Internal server error
+
+  /communities/{communityId}/members/{userId}:
+    post:
+      tags:
+        - Communities
+      summary: Invite user to community
+      description: Send an invitation to a user to join a community (admin only)
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - name: communityId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: objectid
+            description: MongoDB ObjectID of the community
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: objectid
+            description: MongoDB ObjectID of the user to invite
+      responses:
+        '201':
+          description: Invitation sent successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommunityInvite'
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - User is not an admin of this community
+        '404':
+          description: Community or user not found
+        '409':
+          description: User is already a member or has a pending invitation
+        '500':
+          description: Internal server error
+    delete:
+      tags:
+        - Communities
+      summary: Remove user from community
+      description: Remove a user from a community (admin can remove any user, members can remove themselves)
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - name: communityId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: objectid
+            description: MongoDB ObjectID of the community
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: objectid
+            description: MongoDB ObjectID of the user to remove
+      responses:
+        '204':
+          description: User removed successfully
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - User is not authorized to remove this member
+        '404':
+          description: Community or user not found
+        '500':
+          description: Internal server error
+
+  /communities/invites:
+    get:
+      tags:
+        - Communities
+      summary: Get pending community invites
+      description: Get all pending community invitations for the authenticated user
+      security:
+        - bearerAuth: [ ]
+      responses:
+        '200':
+          description: List of pending invitations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CommunityInvite'
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal server error
+
+  /communities/invites/{inviteId}:
+    put:
+      tags:
+        - Communities
+      summary: Update invite status
+      description: Accept or reject a community invitation
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - name: inviteId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: objectid
+            description: MongoDB ObjectID of the invitation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InviteStatusUpdate'
+      responses:
+        '200':
+          description: Invitation status updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommunityInvite'
+        '400':
+          description: Invalid request body
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - User is not the invited user
+        '404':
+          description: Invitation not found
+        '500':
+          description: Internal server error

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -122,6 +122,87 @@ components:
           nullable: true
           description: List of communities ids where the user belongs to
 
+    UserPreview:
+      type: object
+      properties:
+        id:
+          type: string
+          format: objectid
+          description: MongoDB ObjectID of the user
+        name:
+          type: string
+          description: User's display name
+        avatarHash:
+          type: string
+          format: byte
+          description: Hash of the user's avatar image
+        ratingCount:
+          type: integer
+          description: Number of ratings received by the user
+        rating:
+          type: integer
+          description: Average rating of the user
+        active:
+          type: boolean
+          description: Whether the user is currently active
+
+    User:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/UserPreview'
+      properties:
+        email:
+          type: string
+          format: email
+          description: User's email address
+        community:
+          type: string
+          description: User's community name
+        tokens:
+          type: integer
+          format: uint64
+          description: User's token balance
+        location:
+          $ref: '#/components/schemas/Location'
+          description: User's geographical location
+        verified:
+          type: boolean
+          description: Whether the user's email is verified
+        createdAt:
+          type: string
+          format: date-time
+          description: When the user account was created
+        lastSeen:
+          type: string
+          format: date-time
+          description: When the user was last active
+        bio:
+          type: string
+          description: User's biography or description
+        inviteCodes:
+          type: array
+          items:
+            type: object
+            properties:
+              code:
+                type: string
+              createdOn:
+                type: string
+                format: date-time
+          description: List of invitation codes owned by the user
+        communities:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: objectid
+              role:
+                type: string
+                enum: [ADMIN, MEMBER]
+          description: List of communities the user belongs to with their roles
+
     UserProfile:
       type: object
       properties:
@@ -358,6 +439,16 @@ components:
         requester:
           $ref: '#/components/schemas/RatingParty'
           description: Rating information for the requester
+
+    CommunityUserResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/UserPreview'
+      properties:
+        role:
+          type: string
+          enum: [ADMIN, MEMBER]
+          description: Role of the user in the community
 
     Community:
       type: object
@@ -1368,7 +1459,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/UserProfile'
+                  $ref: '#/components/schemas/CommunityUserResponse'
         '401':
           description: Unauthorized
         '404':

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -523,7 +523,7 @@ components:
           description: MongoDB ObjectID of the user who sent the invite
         status:
           type: string
-          enum: [PENDING, ACCEPTED, REJECTED]
+          enum: [PENDING, ACCEPTED, REJECTED, CANCELED]
           description: Status of the invite
         createdAt:
           type: string
@@ -541,7 +541,7 @@ components:
       properties:
         status:
           type: string
-          enum: [ACCEPTED, REJECTED]
+          enum: [ACCEPTED, REJECTED, CANCELED]
           description: New status for the invite
 
     BookingStatusUpdate:
@@ -1570,7 +1570,7 @@ paths:
       tags:
         - Communities
       summary: Update invite status
-      description: Accept or reject a community invitation
+      description: Accept, reject, or cancel a community invitation. Only the invited user can accept or reject, and only the inviter can cancel.
       security:
         - bearerAuth: [ ]
       parameters:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1466,6 +1466,43 @@ paths:
                 items:
                   $ref: '#/components/schemas/CommunityUserResponse'
         '401':
+           description: Unauthorized
+        '404':
+          description: Community not found
+        '500':
+          description: Internal server error
+          
+  /communities/{communityId}/tools:
+    get:
+      tags:
+        - Communities
+      summary: Get tools shared within a community
+      description: Get all tools that are shared within a specific community
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - name: communityId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: objectid
+            description: MongoDB ObjectID of the community
+      responses:
+        '200':
+          description: List of tools in the community
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tools:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Tool'
+        '400':
+          description: Invalid community ID
+        '401':
           description: Unauthorized
         '404':
           description: Community not found

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1344,7 +1344,7 @@ paths:
         '500':
           description: Internal server error
 
-  /communities/{communityId}/users:
+  /communities/{communityId}/members:
     get:
       tags:
         - Communities

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -662,6 +662,11 @@ paths:
             minimum: 0
             default: 0
             description: Page number for pagination (0-based, 16 items per page)
+        - name: username
+          in: query
+          schema:
+            type: string
+          description: Optional parameter to search users by partial name match
       responses:
         '200':
           description: List of users

--- a/test/community_test.go
+++ b/test/community_test.go
@@ -235,6 +235,8 @@ func TestCommunities(t *testing.T) {
 		qt.Assert(t, inviteResp.Data.CommunityID, qt.Equals, communityID)
 		qt.Assert(t, inviteResp.Data.UserID, qt.Equals, nonMemberID)
 		qt.Assert(t, inviteResp.Data.Status, qt.Equals, "PENDING")
+		// Verify community information is included
+		qt.Assert(t, inviteResp.Data.Community.Name, qt.Not(qt.Equals), "")
 		inviteID := inviteResp.Data.ID
 
 		// Test getting pending invites without auth
@@ -252,6 +254,8 @@ func TestCommunities(t *testing.T) {
 		qt.Assert(t, err, qt.IsNil)
 		qt.Assert(t, len(invitesResp.Data), qt.Equals, 1)
 		qt.Assert(t, invitesResp.Data[0].ID, qt.Equals, inviteID)
+		// Verify community information is included in the invite response
+		qt.Assert(t, invitesResp.Data[0].Community.Name, qt.Not(qt.Equals), "")
 
 		// Test accepting an invite without auth
 		_, code = c.Request(http.MethodPut, "",

--- a/test/community_test.go
+++ b/test/community_test.go
@@ -223,6 +223,10 @@ func TestCommunities(t *testing.T) {
 		_, code = c.Request(http.MethodPost, "", nil, "communities", communityID, "members", nonMemberID)
 		qt.Assert(t, code, qt.Equals, 401)
 
+		// Test user trying to invite themselves (should fail)
+		_, code = c.Request(http.MethodPost, ownerJWT, nil, "communities", communityID, "members", ownerID)
+		qt.Assert(t, code, qt.Equals, 400) // Bad request - users cannot invite themselves
+
 		// Test inviting a user with auth
 		resp, code = c.Request(http.MethodPost, ownerJWT, nil, "communities", communityID, "members", nonMemberID)
 		qt.Assert(t, code, qt.Equals, 200)

--- a/test/community_test.go
+++ b/test/community_test.go
@@ -138,11 +138,11 @@ func TestCommunities(t *testing.T) {
 		communityID := createResp.Data.ID
 
 		// Test getting community users without auth
-		_, code = c.Request(http.MethodGet, "", nil, "communities", communityID, "users")
+		_, code = c.Request(http.MethodGet, "", nil, "communities", communityID, "members")
 		qt.Assert(t, code, qt.Equals, 401)
 
 		// Test getting community users with auth
-		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "users")
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "members")
 		qt.Assert(t, code, qt.Equals, 200)
 
 		var usersResp struct {
@@ -183,21 +183,21 @@ func TestCommunities(t *testing.T) {
 		qt.Assert(t, code, qt.Equals, 200)
 
 		// Verify the member is now in the community
-		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "users")
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "members")
 		qt.Assert(t, code, qt.Equals, 200)
 		err = json.Unmarshal(resp, &usersResp)
 		qt.Assert(t, err, qt.IsNil)
 		qt.Assert(t, len(usersResp.Data), qt.Equals, 2) // Owner and member
 
 		// Test pagination with page parameter
-		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "users?page=0")
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "members?page=0")
 		qt.Assert(t, code, qt.Equals, 200)
 		err = json.Unmarshal(resp, &usersResp)
 		qt.Assert(t, err, qt.IsNil)
 		qt.Assert(t, len(usersResp.Data), qt.Equals, 2) // Should return all users since we have less than page size
 
 		// Test invalid page number
-		_, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "users?page=-1")
+		_, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "members?page=-1")
 		qt.Assert(t, code, qt.Equals, 400)
 	})
 
@@ -277,7 +277,7 @@ func TestCommunities(t *testing.T) {
 		qt.Assert(t, code, qt.Equals, 200)
 
 		// Verify the user is now in the community
-		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "users")
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "members")
 		qt.Assert(t, code, qt.Equals, 200)
 		var usersResp struct {
 			Data []api.CommunityUserResponse `json:"data"`
@@ -340,7 +340,7 @@ func TestCommunities(t *testing.T) {
 		qt.Assert(t, code, qt.Equals, 200)
 
 		// Verify the user is not in the community
-		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", rejectionCommunityID, "users")
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", rejectionCommunityID, "members")
 		qt.Assert(t, code, qt.Equals, 200)
 		err = json.Unmarshal(resp, &usersResp)
 		qt.Assert(t, err, qt.IsNil)
@@ -427,7 +427,7 @@ func TestCommunities(t *testing.T) {
 		qt.Assert(t, code, qt.Equals, 200)
 
 		// Verify the member is now in the community
-		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", updateInviteCommunityID, "users")
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", updateInviteCommunityID, "members")
 		qt.Assert(t, code, qt.Equals, 200)
 		err = json.Unmarshal(resp, &usersResp)
 		qt.Assert(t, err, qt.IsNil)
@@ -471,7 +471,7 @@ func TestCommunities(t *testing.T) {
 		qt.Assert(t, code, qt.Equals, 200)
 
 		// Verify the member is not in the community
-		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", newRejectionCommunityID, "users")
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", newRejectionCommunityID, "members")
 		qt.Assert(t, code, qt.Equals, 200)
 		err = json.Unmarshal(resp, &usersResp)
 		qt.Assert(t, err, qt.IsNil)
@@ -549,7 +549,7 @@ func TestCommunities(t *testing.T) {
 		qt.Assert(t, code, qt.Equals, 200)
 
 		// Verify the member is no longer in the community
-		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "users")
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "members")
 		qt.Assert(t, code, qt.Equals, 200)
 		var usersResp struct {
 			Data []api.CommunityUserResponse `json:"data"`

--- a/test/community_test.go
+++ b/test/community_test.go
@@ -1,0 +1,597 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/emprius/emprius-app-backend/api"
+	"github.com/emprius/emprius-app-backend/test/utils"
+	qt "github.com/frankban/quicktest"
+)
+
+func TestCommunities(t *testing.T) {
+	c := utils.NewTestService(t)
+
+	// Create users for testing
+	ownerJWT, ownerID := c.RegisterAndLoginWithID("community-owner@test.com", "owner", "ownerpass")
+	memberJWT, memberID := c.RegisterAndLoginWithID("community-member@test.com", "member", "memberpass")
+	nonMemberJWT, nonMemberID := c.RegisterAndLoginWithID("community-nonmember@test.com", "nonmember", "nonmemberpass")
+
+	t.Run("Community Creation and Management", func(t *testing.T) {
+		// Test creating a community without auth
+		_, code := c.Request(http.MethodPost, "",
+			api.CreateCommunityRequest{
+				Name: "Test Community",
+			},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 401)
+
+		// Test creating a community with auth
+		resp, code := c.Request(http.MethodPost, ownerJWT,
+			api.CreateCommunityRequest{
+				Name: "Test Community",
+			},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var createResp struct {
+			Data api.CommunityResponse `json:"data"`
+		}
+		err := json.Unmarshal(resp, &createResp)
+		qt.Assert(t, err, qt.IsNil)
+		communityID := createResp.Data.ID
+
+		// Test getting community details
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var getResp struct {
+			Data api.CommunityResponse `json:"data"`
+		}
+		err = json.Unmarshal(resp, &getResp)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, getResp.Data.Name, qt.Equals, "Test Community")
+		qt.Assert(t, getResp.Data.OwnerID, qt.Equals, ownerID)
+
+		// Test updating community without auth
+		_, code = c.Request(http.MethodPut, "",
+			api.UpdateCommunityRequest{
+				Name: "Updated Community",
+			},
+			"communities", communityID,
+		)
+		qt.Assert(t, code, qt.Equals, 401)
+
+		// Test updating community as non-owner
+		_, code = c.Request(http.MethodPut, memberJWT,
+			api.UpdateCommunityRequest{
+				Name: "Updated Community",
+			},
+			"communities", communityID,
+		)
+		qt.Assert(t, code, qt.Equals, 401)
+
+		// Test updating community as owner
+		_, code = c.Request(http.MethodPut, ownerJWT,
+			api.UpdateCommunityRequest{
+				Name: "Updated Community",
+			},
+			"communities", communityID,
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Verify the update
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID)
+		qt.Assert(t, code, qt.Equals, 200)
+		err = json.Unmarshal(resp, &getResp)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, getResp.Data.Name, qt.Equals, "Updated Community")
+
+		// Test deleting community without auth
+		_, code = c.Request(http.MethodDelete, "", nil, "communities", communityID)
+		qt.Assert(t, code, qt.Equals, 401)
+
+		// Test deleting community as non-owner
+		_, code = c.Request(http.MethodDelete, memberJWT, nil, "communities", communityID)
+		qt.Assert(t, code, qt.Equals, 401)
+
+		// Create a second community for deletion test
+		resp, code = c.Request(http.MethodPost, ownerJWT,
+			api.CreateCommunityRequest{
+				Name: "Community to Delete",
+			},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+		err = json.Unmarshal(resp, &createResp)
+		qt.Assert(t, err, qt.IsNil)
+		communityToDeleteID := createResp.Data.ID
+
+		// Test deleting community as owner
+		_, code = c.Request(http.MethodDelete, ownerJWT, nil, "communities", communityToDeleteID)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Verify the deletion
+		_, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityToDeleteID)
+		qt.Assert(t, code, qt.Equals, 500) // Internal server error when community not found
+	})
+
+	t.Run("Community Users", func(t *testing.T) {
+		// Create a community for testing
+		resp, code := c.Request(http.MethodPost, ownerJWT,
+			api.CreateCommunityRequest{
+				Name: "Users Test Community",
+			},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var createResp struct {
+			Data api.CommunityResponse `json:"data"`
+		}
+		err := json.Unmarshal(resp, &createResp)
+		qt.Assert(t, err, qt.IsNil)
+		communityID := createResp.Data.ID
+
+		// Test getting community users without auth
+		_, code = c.Request(http.MethodGet, "", nil, "communities", communityID, "users")
+		qt.Assert(t, code, qt.Equals, 401)
+
+		// Test getting community users with auth
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "users")
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var usersResp struct {
+			Data []api.CommunityUserResponse `json:"data"`
+		}
+		err = json.Unmarshal(resp, &usersResp)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, len(usersResp.Data), qt.Equals, 1) // Only the owner should be in the community initially
+
+		// Verify the owner is in the community with the correct role
+		data := usersResp.Data[0]
+		qt.Assert(t, data.ID, qt.Equals, ownerID)
+		qt.Assert(t, string(usersResp.Data[0].Role), qt.Equals, "owner")
+
+		// Test pagination by creating a community with multiple users
+		// First invite and accept a user to the community
+		_, code = c.Request(http.MethodPost, ownerJWT, nil, "communities", communityID, "invite", memberID)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Get pending invites for the member
+		resp, code = c.Request(http.MethodGet, memberJWT, nil, "users", "invites")
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var invitesResp struct {
+			Data []api.CommunityInviteResponse `json:"data"`
+		}
+		err = json.Unmarshal(resp, &invitesResp)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, len(invitesResp.Data), qt.Equals, 1)
+		inviteID := invitesResp.Data[0].ID
+
+		// Accept the invitation
+		_, code = c.Request(http.MethodPost, memberJWT, nil, "users", "invites", inviteID, "accept")
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Verify the member is now in the community
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "users")
+		qt.Assert(t, code, qt.Equals, 200)
+		err = json.Unmarshal(resp, &usersResp)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, len(usersResp.Data), qt.Equals, 2) // Owner and member
+
+		// Test pagination with page parameter
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "users?page=0")
+		qt.Assert(t, code, qt.Equals, 200)
+		err = json.Unmarshal(resp, &usersResp)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, len(usersResp.Data), qt.Equals, 2) // Should return all users since we have less than page size
+
+		// Test invalid page number
+		_, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "users?page=-1")
+		qt.Assert(t, code, qt.Equals, 400)
+	})
+
+	t.Run("Community Invitations", func(t *testing.T) {
+		// Create a community for testing
+		resp, code := c.Request(http.MethodPost, ownerJWT,
+			api.CreateCommunityRequest{
+				Name: "Invitations Test Community",
+			},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var createResp struct {
+			Data api.CommunityResponse `json:"data"`
+		}
+		err := json.Unmarshal(resp, &createResp)
+		qt.Assert(t, err, qt.IsNil)
+		communityID := createResp.Data.ID
+
+		// Test inviting a user without auth
+		_, code = c.Request(http.MethodPost, "", nil, "communities", communityID, "invite", nonMemberID)
+		qt.Assert(t, code, qt.Equals, 401)
+
+		// Test inviting a user with auth
+		resp, code = c.Request(http.MethodPost, ownerJWT, nil, "communities", communityID, "invite", nonMemberID)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var inviteResp struct {
+			Data api.CommunityInviteResponse `json:"data"`
+		}
+		err = json.Unmarshal(resp, &inviteResp)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, inviteResp.Data.CommunityID, qt.Equals, communityID)
+		qt.Assert(t, inviteResp.Data.UserID, qt.Equals, nonMemberID)
+		qt.Assert(t, inviteResp.Data.Status, qt.Equals, "pending")
+		inviteID := inviteResp.Data.ID
+
+		// Test getting pending invites without auth
+		_, code = c.Request(http.MethodGet, "", nil, "users", "invites")
+		qt.Assert(t, code, qt.Equals, 401)
+
+		// Test getting pending invites with auth
+		resp, code = c.Request(http.MethodGet, nonMemberJWT, nil, "users", "invites")
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var invitesResp struct {
+			Data []api.CommunityInviteResponse `json:"data"`
+		}
+		err = json.Unmarshal(resp, &invitesResp)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, len(invitesResp.Data), qt.Equals, 1)
+		qt.Assert(t, invitesResp.Data[0].ID, qt.Equals, inviteID)
+
+		// Test accepting an invite without auth
+		_, code = c.Request(http.MethodPost, "", nil, "users", "invites", inviteID, "accept")
+		qt.Assert(t, code, qt.Equals, 401)
+
+		// Test accepting an invite with wrong user
+		_, code = c.Request(http.MethodPost, memberJWT, nil, "users", "invites", inviteID, "accept")
+		qt.Assert(t, code, qt.Equals, 500) // Internal server error when invite not found for this user
+
+		// Test accepting an invite with correct user
+		_, code = c.Request(http.MethodPost, nonMemberJWT, nil, "users", "invites", inviteID, "accept")
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Verify the user is now in the community
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "users")
+		qt.Assert(t, code, qt.Equals, 200)
+		var usersResp struct {
+			Data []api.CommunityUserResponse `json:"data"`
+		}
+		err = json.Unmarshal(resp, &usersResp)
+		qt.Assert(t, err, qt.IsNil)
+
+		// Find the non-member in the users list
+		var found bool
+		for _, user := range usersResp.Data {
+			if user.ID == nonMemberID {
+				found = true
+				qt.Assert(t, string(user.Role), qt.Equals, "user")
+				break
+			}
+		}
+		qt.Assert(t, found, qt.IsTrue)
+
+		// Create another community for testing invite rejection
+		resp, code = c.Request(http.MethodPost, ownerJWT,
+			api.CreateCommunityRequest{
+				Name: "Rejection Test Community",
+			},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+		err = json.Unmarshal(resp, &createResp)
+		qt.Assert(t, err, qt.IsNil)
+		rejectionCommunityID := createResp.Data.ID
+
+		// Invite the member to the new community
+		resp, code = c.Request(http.MethodPost, ownerJWT, nil, "communities", rejectionCommunityID, "invite", memberID)
+		qt.Assert(t, code, qt.Equals, 200)
+		err = json.Unmarshal(resp, &inviteResp)
+		qt.Assert(t, err, qt.IsNil)
+		rejectInviteID := inviteResp.Data.ID
+
+		// Test rejecting an invite without auth
+		_, code = c.Request(http.MethodPost, "", nil, "users", "invites", rejectInviteID, "refuse")
+		qt.Assert(t, code, qt.Equals, 401)
+
+		// Test rejecting an invite with wrong user
+		_, code = c.Request(http.MethodPost, nonMemberJWT, nil, "users", "invites", rejectInviteID, "refuse")
+		qt.Assert(t, code, qt.Equals, 500) // Internal server error when invite not found for this user
+
+		// Test rejecting an invite with correct user
+		_, code = c.Request(http.MethodPost, memberJWT, nil, "users", "invites", rejectInviteID, "refuse")
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Verify the user is not in the community
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", rejectionCommunityID, "users")
+		qt.Assert(t, code, qt.Equals, 200)
+		err = json.Unmarshal(resp, &usersResp)
+		qt.Assert(t, err, qt.IsNil)
+
+		// Ensure the member is not in the community
+		found = false
+		for _, user := range usersResp.Data {
+			if user.ID == memberID {
+				found = true
+				break
+			}
+		}
+		qt.Assert(t, found, qt.IsFalse)
+
+		// Test counting pending invites
+		// Create a new community and invite the member
+		resp, code = c.Request(http.MethodPost, ownerJWT,
+			api.CreateCommunityRequest{
+				Name: "Count Test Community",
+			},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+		err = json.Unmarshal(resp, &createResp)
+		qt.Assert(t, err, qt.IsNil)
+		countCommunityID := createResp.Data.ID
+
+		// Invite the member to the new community
+		_, code = c.Request(http.MethodPost, ownerJWT, nil, "communities", countCommunityID, "invite", memberID)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Get pending counts
+		resp, code = c.Request(http.MethodGet, memberJWT, nil, "profile", "pendings")
+		qt.Assert(t, code, qt.Equals, 200)
+		var pendingsResp struct {
+			Data api.PendingActionsResponse `json:"data"`
+		}
+		err = json.Unmarshal(resp, &pendingsResp)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, pendingsResp.Data.PendingInvitesCount, qt.Equals, int64(1))
+	})
+
+	t.Run("Community Membership", func(t *testing.T) {
+		// Create a community for testing
+		resp, code := c.Request(http.MethodPost, ownerJWT,
+			api.CreateCommunityRequest{
+				Name: "Membership Test Community",
+			},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var createResp struct {
+			Data api.CommunityResponse `json:"data"`
+		}
+		err := json.Unmarshal(resp, &createResp)
+		qt.Assert(t, err, qt.IsNil)
+		communityID := createResp.Data.ID
+
+		// Invite and accept a user to the community
+		_, code = c.Request(http.MethodPost, ownerJWT, nil, "communities", communityID, "invite", memberID)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Get pending invites for the member
+		resp, code = c.Request(http.MethodGet, memberJWT, nil, "users", "invites")
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var invitesResp struct {
+			Data []api.CommunityInviteResponse `json:"data"`
+		}
+		err = json.Unmarshal(resp, &invitesResp)
+		qt.Assert(t, err, qt.IsNil)
+
+		// Find the invite for this community
+		var inviteID string
+		for _, invite := range invitesResp.Data {
+			if invite.CommunityID == communityID {
+				inviteID = invite.ID
+				break
+			}
+		}
+		qt.Assert(t, inviteID, qt.Not(qt.Equals), "")
+
+		// Accept the invitation
+		_, code = c.Request(http.MethodPost, memberJWT, nil, "users", "invites", inviteID, "accept")
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Test leaving a community without auth
+		_, code = c.Request(http.MethodPost, "", nil, "communities", communityID, "leave")
+		qt.Assert(t, code, qt.Equals, 401)
+
+		// Test owner trying to leave the community (should fail)
+		_, code = c.Request(http.MethodPost, ownerJWT, nil, "communities", communityID, "leave")
+		qt.Assert(t, code, qt.Equals, 500) // Internal server error with message "community owner cannot leave the community"
+
+		// Test member leaving the community
+		_, code = c.Request(http.MethodPost, memberJWT, nil, "communities", communityID, "leave")
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Verify the member is no longer in the community
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "users")
+		qt.Assert(t, code, qt.Equals, 200)
+		var usersResp struct {
+			Data []api.CommunityUserResponse `json:"data"`
+		}
+		err = json.Unmarshal(resp, &usersResp)
+		qt.Assert(t, err, qt.IsNil)
+
+		// Ensure the member is not in the community
+		found := false
+		for _, user := range usersResp.Data {
+			if user.ID == memberID {
+				found = true
+				break
+			}
+		}
+		qt.Assert(t, found, qt.IsFalse)
+
+		// Verify user roles in communities
+		// Get the owner's profile
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "profile")
+		qt.Assert(t, code, qt.Equals, 200)
+		var profileResp struct {
+			Data api.User `json:"data"`
+		}
+		err = json.Unmarshal(resp, &profileResp)
+		qt.Assert(t, err, qt.IsNil)
+
+		// Find the community in the owner's communities
+		found = false
+		for _, comm := range profileResp.Data.Communities {
+			if comm.ID == communityID {
+				found = true
+				qt.Assert(t, string(comm.Role), qt.Equals, "owner")
+				break
+			}
+		}
+		qt.Assert(t, found, qt.IsTrue)
+	})
+
+	t.Run("Modified Endpoints", func(t *testing.T) {
+		// Create a community for testing
+		resp, code := c.Request(http.MethodPost, ownerJWT,
+			api.CreateCommunityRequest{
+				Name: "Modified Endpoints Test Community",
+			},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var createResp struct {
+			Data api.CommunityResponse `json:"data"`
+		}
+		err := json.Unmarshal(resp, &createResp)
+		qt.Assert(t, err, qt.IsNil)
+		communityID := createResp.Data.ID
+
+		// Test GET profile/pendings with pending invites count
+		// Invite the member to the community
+		_, code = c.Request(http.MethodPost, ownerJWT, nil, "communities", communityID, "invite", memberID)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Get pending counts for the member
+		resp, code = c.Request(http.MethodGet, memberJWT, nil, "profile", "pendings")
+		qt.Assert(t, code, qt.Equals, 200)
+		var pendingsResp struct {
+			Data api.PendingActionsResponse `json:"data"`
+		}
+		err = json.Unmarshal(resp, &pendingsResp)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, pendingsResp.Data.PendingInvitesCount > 0, qt.IsTrue)
+
+		// Test GET users/ with username search filter
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "users?username=member")
+		qt.Assert(t, code, qt.Equals, 200)
+		var usersResp struct {
+			Data struct {
+				Users []api.User `json:"users"`
+			} `json:"data"`
+		}
+		err = json.Unmarshal(resp, &usersResp)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, len(usersResp.Data.Users) > 0, qt.IsTrue)
+
+		// Verify at least one user with "member" in the name is found
+		found := false
+		for _, user := range usersResp.Data.Users {
+			if user.ID == memberID {
+				found = true
+				break
+			}
+		}
+		qt.Assert(t, found, qt.IsTrue)
+
+		// Test tool response with communities array
+		// Create a tool
+		toolID := c.CreateTool(ownerJWT, "Community Tool")
+
+		// Add the tool to the community
+		_, code = c.Request(http.MethodPut, ownerJWT,
+			map[string]interface{}{
+				"communities": []string{communityID},
+			},
+			"tools", fmt.Sprint(toolID),
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Get the tool and verify it has the community
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "tools", fmt.Sprint(toolID))
+		qt.Assert(t, code, qt.Equals, 200)
+		var toolResp struct {
+			Data api.Tool `json:"data"`
+		}
+		err = json.Unmarshal(resp, &toolResp)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, len(toolResp.Data.Communities), qt.Equals, 1)
+		qt.Assert(t, toolResp.Data.Communities[0], qt.Equals, communityID)
+
+		// Test PUT/POST tools with communities array
+		// Create a new tool with community
+		resp, code = c.Request(http.MethodPost, ownerJWT,
+			map[string]interface{}{
+				"title":          "Another Community Tool",
+				"description":    "Test tool with community",
+				"mayBeFree":      true,
+				"askWithFee":     false,
+				"cost":           10,
+				"toolCategory":   1,
+				"estimatedValue": 20,
+				"height":         30,
+				"weight":         40,
+				"communities":    []string{communityID},
+				"location": map[string]interface{}{
+					"latitude":  41695384,
+					"longitude": 2492793,
+				},
+			},
+			"tools",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+		var newToolResp struct {
+			Data struct {
+				ID int64 `json:"id"`
+			} `json:"data"`
+		}
+		err = json.Unmarshal(resp, &newToolResp)
+		qt.Assert(t, err, qt.IsNil)
+		newToolID := newToolResp.Data.ID
+
+		// Get the new tool and verify it has the community
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "tools", fmt.Sprint(newToolID))
+		qt.Assert(t, code, qt.Equals, 200)
+		err = json.Unmarshal(resp, &toolResp)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, len(toolResp.Data.Communities), qt.Equals, 1)
+		qt.Assert(t, toolResp.Data.Communities[0], qt.Equals, communityID)
+
+		// Test user/profile response with communities attribute
+		// Get the owner's profile
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "profile")
+		qt.Assert(t, code, qt.Equals, 200)
+		var profileResp struct {
+			Data api.User `json:"data"`
+		}
+		err = json.Unmarshal(resp, &profileResp)
+		qt.Assert(t, err, qt.IsNil)
+
+		// Verify the owner has communities in their profile
+		qt.Assert(t, len(profileResp.Data.Communities) > 0, qt.IsTrue)
+
+		// Find the test community in the owner's communities
+		found = false
+		for _, comm := range profileResp.Data.Communities {
+			if comm.ID == communityID {
+				found = true
+				qt.Assert(t, comm.Role, qt.Equals, "owner")
+				break
+			}
+		}
+		qt.Assert(t, found, qt.IsTrue)
+	})
+}

--- a/test/community_test.go
+++ b/test/community_test.go
@@ -56,6 +56,7 @@ func TestCommunities(t *testing.T) {
 		qt.Assert(t, err, qt.IsNil)
 		qt.Assert(t, getResp.Data.Name, qt.Equals, "Test Community")
 		qt.Assert(t, getResp.Data.OwnerID, qt.Equals, ownerID)
+		qt.Assert(t, getResp.Data.MembersCount, qt.Equals, int64(1)) // Only the owner should be in the community initially
 
 		// Test updating community without auth
 		_, code = c.Request(http.MethodPut, "",
@@ -731,9 +732,13 @@ func TestCommunities(t *testing.T) {
 		for _, community := range communitiesResp.Data {
 			if community.ID == community1ID {
 				foundCommunity1 = true
+				// Verify the member count is at least 2 (owner and member)
+				qt.Assert(t, community.MembersCount >= 2, qt.IsTrue)
 			}
 			if community.ID == community2ID {
 				foundCommunity2 = true
+				// Verify the member count is at least 1 (just the owner)
+				qt.Assert(t, community.MembersCount >= 1, qt.IsTrue)
 			}
 		}
 		qt.Assert(t, foundCommunity1, qt.IsTrue)

--- a/test/community_test.go
+++ b/test/community_test.go
@@ -827,7 +827,7 @@ func TestCommunities(t *testing.T) {
 		qt.Assert(t, pendingsResp.Data.PendingInvitesCount > 0, qt.IsTrue)
 
 		// Test GET users/ with username search filter
-		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "users?username=member")
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "users?username=kkk")
 		qt.Assert(t, code, qt.Equals, 200)
 		var usersResp struct {
 			Data struct {


### PR DESCRIPTION
Fix #51 

It implement communities:

- A user can belong to one or more communities
- A user can create communities
- A community member can share a tool inside of a community
- Tools from a community can only be rented by members of the community. User from outside a community cannot rent a tool.
- Two roles on a community: owner and member
- The owner can invite and remove users on the community
- New query param to search user by partial username
- Tools that belong to a community doesn't appear on the search if the auth user is not on the community.
