### PR TITLE
Fix obfuscation issues

### DIFF
--- a/api/jwtauth.go
+++ b/api/jwtauth.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"time"
@@ -65,8 +67,8 @@ func (a *API) makeToken(id string) (*LoginResponse, error) {
 }
 
 // HashPassword helper function allows to hash a password using a salt.
-func hashPassword(password string) []byte {
-	return argon2hash([]byte(password), []byte(passwordSalt))
+func hashPassword(password, salt string) []byte {
+	return argon2hash([]byte(password), []byte(salt))
 }
 
 func argon2hash(data, salt []byte) []byte {
@@ -75,4 +77,17 @@ func argon2hash(data, salt []byte) []byte {
 	argonTime := uint32(4)
 	argonThreads := uint8(8)
 	return argon2.IDKey([]byte(data), []byte(salt), argonTime, memory, argonThreads, 32)
+}
+
+// generateRandomSalt generates a cryptographically secure random salt
+func generateRandomSalt() (string, error) {
+	// Generate 32 bytes of random data (256 bits)
+	saltBytes := make([]byte, 32)
+	_, err := rand.Read(saltBytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate random salt: %w", err)
+	}
+
+	// Convert to hex string for storage
+	return hex.EncodeToString(saltBytes), nil
 }

--- a/api/tools.go
+++ b/api/tools.go
@@ -400,7 +400,14 @@ func (a *API) toolHandler(r *Request) (interface{}, error) {
 	}
 
 	// Only show real location if user is authenticated and is the owner
-	useRealLocation := dbTool.UserID == requestingUserID || dbTool.ActualUserID == requestingUserID
+	useRealLocation := !dbTool.IsNomadic && dbTool.UserID == requestingUserID
+	// Or if the tool is nomadic and the user is the actual user
+	if dbTool.IsNomadic && dbTool.ActualUserID == requestingUserID {
+		useRealLocation = true
+		// Or if the tool is nomadic and the user is the owner and the actual user is not set
+	} else if dbTool.IsNomadic && dbTool.ActualUserID.IsZero() && dbTool.UserID == requestingUserID {
+		useRealLocation = true
+	}
 
 	// Convert DB tool to API tool with appropriate location
 	tool := new(Tool).FromDBTool(dbTool, a.database, useRealLocation)

--- a/api/tools.go
+++ b/api/tools.go
@@ -173,7 +173,7 @@ func (a *API) addTool(t *Tool, userID string) (int64, error) {
 		MaxDistance:        t.MaxDistance,
 		Images:             dbImages,
 		Location:           realLocation,
-		ObfuscatedLocation: db.ObfuscateLocation(realLocation, user.ID),
+		ObfuscatedLocation: db.ObfuscateLocation(realLocation, user.ID, user.Salt),
 		TransportOptions:   transportOptions,
 		ReservedDates:      []db.DateRange{}, // Initialize empty array
 		IsNomadic:          *t.IsNomadic,
@@ -210,7 +210,7 @@ func (a *API) toolFromDB(id int64) (*db.Tool, error) {
 	return tool, nil
 }
 
-func (a *API) editTool(id int64, newTool *Tool, userID primitive.ObjectID) (int64, error) {
+func (a *API) editTool(id int64, newTool *Tool, user *db.User) (int64, error) {
 	tool, err := a.toolFromDB(id)
 	if err != nil {
 		return 0, err
@@ -276,7 +276,7 @@ func (a *API) editTool(id int64, newTool *Tool, userID primitive.ObjectID) (int6
 	}
 	if newTool.Location.Latitude != 0 || newTool.Location.Longitude != 0 {
 		tool.Location = newTool.Location.ToDBLocation()
-		tool.ObfuscatedLocation = db.ObfuscateLocation(tool.Location, userID)
+		tool.ObfuscatedLocation = db.ObfuscateLocation(tool.Location, user.ID, user.Salt)
 	}
 	if newTool.IsAvailable != nil {
 		tool.IsAvailable = *newTool.IsAvailable
@@ -801,7 +801,7 @@ func (a *API) editToolHandler(r *Request) (interface{}, error) {
 		return nil, err
 	}
 
-	newID, err := a.editTool(id, &t, tool.UserID)
+	newID, err := a.editTool(id, &t, user)
 	if err != nil {
 		return nil, err
 	}

--- a/api/user.go
+++ b/api/user.go
@@ -141,7 +141,7 @@ func (a *API) registerHandler(r *Request) (interface{}, error) {
 	// Generate and update obfuscated location after user is created and ID is assigned
 	if userInfo.Location != nil {
 		// Update the user with obfuscated location
-		obfuscatedLocation := db.ObfuscateLocation(user.Location, id)
+		obfuscatedLocation := db.ObfuscateLocation(user.Location, id, randomSalt)
 		update := bson.M{"obfuscatedLocation": obfuscatedLocation}
 		_, err := a.database.UserService.UpdateUser(context.Background(), id, update)
 		if err != nil {
@@ -489,7 +489,7 @@ func (a *API) userProfileUpdateHandler(r *Request) (interface{}, error) {
 	if newUserInfo.Location != nil {
 		user.Location = newUserInfo.Location.ToDBLocation()
 		// Generate obfuscated location
-		user.ObfuscatedLocation = db.ObfuscateLocation(user.Location, user.ID)
+		user.ObfuscatedLocation = db.ObfuscateLocation(user.Location, user.ID, user.Salt)
 	}
 
 	if newUserInfo.Active != nil {

--- a/api/user.go
+++ b/api/user.go
@@ -105,9 +105,16 @@ func (a *API) registerHandler(r *Request) (interface{}, error) {
 		return nil, ErrMalformedEmail
 	}
 
+	// Generate a random salt for the password
+	randomSalt, err := generateRandomSalt()
+	if err != nil {
+		return nil, ErrInternalServerError.WithErr(fmt.Errorf("failed to generate salt: %w", err))
+	}
+
 	user := db.User{
 		Email:                   userInfo.UserEmail,
-		Password:                hashPassword(userInfo.Password),
+		Password:                hashPassword(userInfo.Password, randomSalt),
+		Salt:                    randomSalt,
 		Name:                    userInfo.Name,
 		Active:                  true,
 		Rating:                  50,
@@ -208,8 +215,16 @@ func (a *API) loginHandler(r *Request) (interface{}, error) {
 	// Check if password is empty (password recovery scenario)
 	if len(user.Password) == 0 {
 		// Password recovery: set the provided password as the new password
-		newPasswordHash := hashPassword(loginInfo.Password)
-		update := bson.M{"password": newPasswordHash}
+		// Use existing salt or set default salt if user doesn't have one
+		salt := user.Salt
+		if salt == "" {
+			salt = passwordSalt
+		}
+		newPasswordHash := hashPassword(loginInfo.Password, salt)
+		update := bson.M{
+			"password": newPasswordHash,
+			"salt":     salt,
+		}
 		_, err = a.database.UserService.UpdateUser(context.Background(), user.ID, update)
 		if err != nil {
 			log.Error().Err(err).Str("userId", user.ID.Hex()).Msg("Failed to update password during recovery")
@@ -220,7 +235,12 @@ func (a *API) loginHandler(r *Request) (interface{}, error) {
 		// Continue with normal login flow after setting password
 	} else {
 		// Normal login: compare passwords
-		if !bytes.Equal(user.Password, hashPassword(loginInfo.Password)) {
+		// Use existing salt or default salt for backward compatibility
+		salt := user.Salt
+		if salt == "" {
+			salt = passwordSalt
+		}
+		if !bytes.Equal(user.Password, hashPassword(loginInfo.Password, salt)) {
 			return nil, ErrWrongLogin
 		}
 	}
@@ -482,12 +502,17 @@ func (a *API) userProfileUpdateHandler(r *Request) (interface{}, error) {
 			return nil, ErrActualPasswordRequired
 		}
 
+		// Use existing salt or default salt for backward compatibility
+		if user.Salt == "" {
+			user.Salt = passwordSalt
+		}
+
 		// Verify the actual password matches the stored password
-		if !bytes.Equal(user.Password, hashPassword(newUserInfo.ActualPassword)) {
+		if !bytes.Equal(user.Password, hashPassword(newUserInfo.ActualPassword, user.Salt)) {
 			return nil, ErrInvalidActualPassword
 		}
 
-		user.Password = hashPassword(newUserInfo.Password)
+		user.Password = hashPassword(newUserInfo.Password, user.Salt)
 	}
 
 	update := bson.M{
@@ -497,6 +522,7 @@ func (a *API) userProfileUpdateHandler(r *Request) (interface{}, error) {
 		"obfuscatedLocation": user.ObfuscatedLocation,
 		"active":             user.Active,
 		"password":           user.Password,
+		"salt":               user.Salt,
 		"community":          user.Community,
 		"bio":                user.Bio,
 		"lastSeen":           time.Now(), // Update lastSeen when profile is updated

--- a/db/location_utils.go
+++ b/db/location_utils.go
@@ -14,15 +14,6 @@ const (
 	DefaultObfuscationRadiusMeters = 1000
 )
 
-// locationSalt is used to add randomness to the obfuscation algorithm
-// It will be set during initialization
-var locationSalt = "emprius-location-salt-v1" // Default value for backward compatibility
-
-// SetLocationSalt sets the salt used for location obfuscation
-func SetLocationSalt(salt string) {
-	locationSalt = salt
-}
-
 // GenerateObfuscatedLocation generates a deterministically randomized location within the specified radius
 func GenerateObfuscatedLocation(location DBLocation, entityID string, salt string, radiusMeters float64) DBLocation {
 	// Create a deterministic seed from the entity ID and salt
@@ -57,6 +48,6 @@ func GenerateObfuscatedLocation(location DBLocation, entityID string, salt strin
 }
 
 // ObfuscateLocation generates an obfuscated location for a user
-func ObfuscateLocation(location DBLocation, seedId primitive.ObjectID) DBLocation {
-	return GenerateObfuscatedLocation(location, seedId.Hex(), locationSalt, DefaultObfuscationRadiusMeters)
+func ObfuscateLocation(location DBLocation, seedId primitive.ObjectID, salt string) DBLocation {
+	return GenerateObfuscatedLocation(location, seedId.Hex(), salt, DefaultObfuscationRadiusMeters)
 }

--- a/db/location_utils_test.go
+++ b/db/location_utils_test.go
@@ -156,6 +156,7 @@ func TestGenerateObfuscatedLocation(t *testing.T) {
 }
 
 func TestObfuscateLocation(t *testing.T) {
+	randomSalt := "random-salt"
 	// Test case 1: Basic functionality
 	t.Run("Basic Functionality", func(t *testing.T) {
 		// Create a test location
@@ -166,7 +167,7 @@ func TestObfuscateLocation(t *testing.T) {
 		seedId := primitive.NewObjectID()
 
 		// Generate obfuscated location
-		obfuscatedLocation := ObfuscateLocation(originalLocation, seedId)
+		obfuscatedLocation := ObfuscateLocation(originalLocation, seedId, randomSalt)
 
 		// Verify the obfuscated location is different from the original
 		if obfuscatedLocation.Coordinates[0] == originalLocation.Coordinates[0] &&
@@ -195,8 +196,8 @@ func TestObfuscateLocation(t *testing.T) {
 		seedId := primitive.NewObjectID()
 
 		// Generate obfuscated location twice with the same inputs
-		obfuscatedLocation1 := ObfuscateLocation(originalLocation, seedId)
-		obfuscatedLocation2 := ObfuscateLocation(originalLocation, seedId)
+		obfuscatedLocation1 := ObfuscateLocation(originalLocation, seedId, randomSalt)
+		obfuscatedLocation2 := ObfuscateLocation(originalLocation, seedId, randomSalt)
 
 		// Verify both obfuscated locations are the same
 		if obfuscatedLocation1.Coordinates[0] != obfuscatedLocation2.Coordinates[0] ||
@@ -216,8 +217,8 @@ func TestObfuscateLocation(t *testing.T) {
 		seedId2 := primitive.NewObjectID()
 
 		// Generate obfuscated locations with different seed IDs
-		obfuscatedLocation1 := ObfuscateLocation(originalLocation, seedId1)
-		obfuscatedLocation2 := ObfuscateLocation(originalLocation, seedId2)
+		obfuscatedLocation1 := ObfuscateLocation(originalLocation, seedId1, randomSalt)
+		obfuscatedLocation2 := ObfuscateLocation(originalLocation, seedId2, randomSalt)
 
 		// Verify the obfuscated locations are different
 		if obfuscatedLocation1.Coordinates[0] == obfuscatedLocation2.Coordinates[0] &&

--- a/db/mongo.go
+++ b/db/mongo.go
@@ -35,11 +35,6 @@ func New(uri string, secret ...string) (*Database, error) {
 		uri = "mongodb://localhost:27017"
 	}
 
-	// Set the location salt if provided
-	if len(secret) > 0 && secret[0] != "" {
-		SetLocationSalt(secret[0])
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/db/user.go
+++ b/db/user.go
@@ -391,7 +391,9 @@ func locationsEqual(loc1, loc2 DBLocation) bool {
 
 // updateToolsLocation updates the location of all tools that match the old user location
 // This includes tools owned by the user and nomadic tools currently held by the user
-func (s *UserService) updateToolsLocation(ctx context.Context, userID primitive.ObjectID, oldLocation, newLocation DBLocation, userSalt string) error {
+func (s *UserService) updateToolsLocation(
+	ctx context.Context, userID primitive.ObjectID, oldLocation, newLocation DBLocation, userSalt string,
+) error {
 	// Get tools collection
 	toolsCollection := s.Collection.Database().Collection("tools")
 

--- a/db/user.go
+++ b/db/user.go
@@ -20,6 +20,7 @@ type User struct {
 	Name                    string              `bson:"name" json:"name"`
 	Community               string              `bson:"community,omitempty" json:"community,omitempty"`
 	Password                []byte              `bson:"password" json:"-"` // Don't include password in JSON
+	Salt                    string              `bson:"salt" json:"-"`     // Don't include salt in JSON
 	Tokens                  uint64              `bson:"tokens" json:"tokens" default:"1000"`
 	Active                  bool                `bson:"active" json:"active" default:"true"`
 	Rating                  int32               `bson:"rating" json:"rating" default:"50"`

--- a/db/user_test.go
+++ b/db/user_test.go
@@ -259,3 +259,364 @@ func TestUserService(t *testing.T) {
 		c.Assert(whitespaceTotal, qt.Equals, int64(0), qt.Commentf("Expected total count to be 0 for whitespace search"))
 	})
 }
+
+func TestUpdateUser_LocationUpdate(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	// Start MongoDB container
+	container, err := StartMongoContainer(ctx)
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to start MongoDB container"))
+	defer func() { _ = container.Terminate(ctx) }()
+
+	// Get MongoDB connection string
+	mongoURI, err := container.Endpoint(ctx, "mongodb")
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to get MongoDB connection string"))
+
+	// Create a MongoDB client
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI))
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to create MongoDB client"))
+	defer func() { _ = client.Disconnect(ctx) }()
+
+	// Use a random database name for isolation
+	dbName := RandomDatabaseName()
+	database := client.Database(dbName)
+
+	// Initialize services
+	db := &Database{
+		Client:   client,
+		Database: database,
+	}
+	userService := NewUserService(db)
+	toolService := NewToolService(db)
+
+	c.Run("Updates Owned Tools", func(c *qt.C) {
+		// Create a user with a specific location
+		userLocation := NewLocation(41385063, 2173404) // Barcelona coordinates
+		user := &User{
+			Email:    "test@example.com",
+			Name:     "Test User",
+			Location: userLocation,
+			Salt:     "testsalt",
+			Active:   true,
+		}
+
+		userResult, err := userService.InsertUser(ctx, user)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert user"))
+		userID := userResult.InsertedID.(primitive.ObjectID)
+
+		// Create tools owned by the user with the same location
+		tool1 := &Tool{
+			ID:       1,
+			Title:    "Tool 1",
+			UserID:   userID,
+			Location: userLocation,
+		}
+		tool2 := &Tool{
+			ID:       2,
+			Title:    "Tool 2",
+			UserID:   userID,
+			Location: userLocation,
+		}
+		// Create a tool with different location (should not be updated)
+		differentLocation := NewLocation(40416775, -3703790) // Madrid coordinates
+		tool3 := &Tool{
+			ID:       3,
+			Title:    "Tool 3",
+			UserID:   userID,
+			Location: differentLocation,
+		}
+
+		_, err = toolService.InsertTool(ctx, tool1)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert tool1"))
+		_, err = toolService.InsertTool(ctx, tool2)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert tool2"))
+		_, err = toolService.InsertTool(ctx, tool3)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert tool3"))
+
+		// Update user location
+		newLocation := NewLocation(48856614, 2352222) // Paris coordinates
+		update := bson.M{
+			"location": newLocation,
+		}
+
+		_, err = userService.UpdateUser(ctx, userID, update)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to update user location"))
+
+		// Verify that tools with matching location were updated
+		updatedTool1, err := toolService.GetToolByID(ctx, 1)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get updated tool1"))
+		c.Assert(updatedTool1.Location.Coordinates, qt.DeepEquals, newLocation.Coordinates, qt.Commentf("Tool1 location not updated"))
+
+		updatedTool2, err := toolService.GetToolByID(ctx, 2)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get updated tool2"))
+		c.Assert(updatedTool2.Location.Coordinates, qt.DeepEquals, newLocation.Coordinates, qt.Commentf("Tool2 location not updated"))
+
+		// Verify that tool with different location was not updated
+		updatedTool3, err := toolService.GetToolByID(ctx, 3)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get updated tool3"))
+		c.Assert(updatedTool3.Location.Coordinates, qt.DeepEquals, differentLocation.Coordinates, qt.Commentf("Tool3 location should not have been updated"))
+	})
+
+	c.Run("Updates Nomadic Tools", func(c *qt.C) {
+		// Create two users
+		userLocation := NewLocation(41385063, 2173404) // Barcelona coordinates
+		user1 := &User{
+			Email:    "user1@example.com",
+			Name:     "User 1",
+			Location: userLocation,
+			Salt:     "testsalt1",
+			Active:   true,
+		}
+		user2 := &User{
+			Email:    "user2@example.com",
+			Name:     "User 2",
+			Location: userLocation,
+			Salt:     "testsalt2",
+			Active:   true,
+		}
+
+		user1Result, err := userService.InsertUser(ctx, user1)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert user1"))
+		user1ID := user1Result.InsertedID.(primitive.ObjectID)
+
+		user2Result, err := userService.InsertUser(ctx, user2)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert user2"))
+		user2ID := user2Result.InsertedID.(primitive.ObjectID)
+
+		// Create a nomadic tool owned by user1 but currently held by user2
+		nomadicTool := &Tool{
+			ID:           4,
+			Title:        "Nomadic Tool",
+			UserID:       user1ID,      // Owned by user1
+			ActualUserID: user2ID,      // Currently held by user2
+			Location:     userLocation, // Same location as user2
+			IsNomadic:    true,
+		}
+
+		_, err = toolService.InsertTool(ctx, nomadicTool)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert nomadic tool"))
+
+		// Update user2's location (the one currently holding the tool)
+		newLocation := NewLocation(48856614, 2352222) // Paris coordinates
+		update := bson.M{
+			"location": newLocation,
+		}
+
+		_, err = userService.UpdateUser(ctx, user2ID, update)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to update user2 location"))
+
+		// Verify that the nomadic tool location was updated
+		updatedTool, err := toolService.GetToolByID(ctx, 4)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get updated nomadic tool"))
+		c.Assert(updatedTool.Location.Coordinates, qt.DeepEquals, newLocation.Coordinates, qt.Commentf("Nomadic tool location not updated"))
+	})
+
+	c.Run("Mixed Scenario", func(c *qt.C) {
+		// Create users
+		userLocation := NewLocation(41385063, 2173404) // Barcelona coordinates
+		user1 := &User{
+			Email:    "user1mixed@example.com",
+			Name:     "User 1 Mixed",
+			Location: userLocation,
+			Salt:     "testsalt1mixed",
+			Active:   true,
+		}
+		user2 := &User{
+			Email:    "user2mixed@example.com",
+			Name:     "User 2 Mixed",
+			Location: userLocation,
+			Salt:     "testsalt2mixed",
+			Active:   true,
+		}
+
+		user1Result, err := userService.InsertUser(ctx, user1)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert user1 for mixed scenario"))
+		user1ID := user1Result.InsertedID.(primitive.ObjectID)
+
+		user2Result, err := userService.InsertUser(ctx, user2)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert user2 for mixed scenario"))
+		user2ID := user2Result.InsertedID.(primitive.ObjectID)
+
+		// Create various tools
+		differentLocation := NewLocation(40416775, -3703790) // Madrid coordinates
+
+		// Tool owned by user1 with matching location (should be updated)
+		ownedTool := &Tool{
+			ID:       5,
+			Title:    "Owned Tool",
+			UserID:   user1ID,
+			Location: userLocation,
+		}
+
+		// Tool owned by user1 with different location (should not be updated)
+		ownedToolDifferent := &Tool{
+			ID:       6,
+			Title:    "Owned Tool Different",
+			UserID:   user1ID,
+			Location: differentLocation,
+		}
+
+		// Nomadic tool held by user1 with matching location (should be updated)
+		nomadicTool := &Tool{
+			ID:           7,
+			Title:        "Nomadic Tool",
+			UserID:       user2ID,      // Owned by user2
+			ActualUserID: user1ID,      // Currently held by user1
+			Location:     userLocation, // Same location as user1
+			IsNomadic:    true,
+		}
+
+		// Tool owned by different user (should not be updated)
+		otherUserTool := &Tool{
+			ID:       8,
+			Title:    "Other User Tool",
+			UserID:   user2ID,
+			Location: userLocation,
+		}
+
+		_, err = toolService.InsertTool(ctx, ownedTool)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert owned tool"))
+		_, err = toolService.InsertTool(ctx, ownedToolDifferent)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert owned tool different"))
+		_, err = toolService.InsertTool(ctx, nomadicTool)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert nomadic tool"))
+		_, err = toolService.InsertTool(ctx, otherUserTool)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert other user tool"))
+
+		// Update user1's location
+		newLocation := NewLocation(48856614, 2352222) // Paris coordinates
+		update := bson.M{
+			"location": newLocation,
+		}
+
+		_, err = userService.UpdateUser(ctx, user1ID, update)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to update user1 location"))
+
+		// Verify owned tool with matching location was updated
+		updatedOwnedTool, err := toolService.GetToolByID(ctx, 5)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get updated owned tool"))
+		c.Assert(updatedOwnedTool.Location.Coordinates, qt.DeepEquals, newLocation.Coordinates, qt.Commentf("Owned tool location not updated"))
+
+		// Verify owned tool with different location was not updated
+		updatedOwnedToolDifferent, err := toolService.GetToolByID(ctx, 6)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get owned tool different"))
+		c.Assert(updatedOwnedToolDifferent.Location.Coordinates, qt.DeepEquals, differentLocation.Coordinates, qt.Commentf("Owned tool different location should not have been updated"))
+
+		// Verify nomadic tool held by user1 was updated
+		updatedNomadicTool, err := toolService.GetToolByID(ctx, 7)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get updated nomadic tool"))
+		c.Assert(updatedNomadicTool.Location.Coordinates, qt.DeepEquals, newLocation.Coordinates, qt.Commentf("Nomadic tool location not updated"))
+
+		// Verify tool owned by different user was not updated
+		updatedOtherUserTool, err := toolService.GetToolByID(ctx, 8)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get other user tool"))
+		c.Assert(updatedOtherUserTool.Location.Coordinates, qt.DeepEquals, userLocation.Coordinates, qt.Commentf("Other user tool location should not have been updated"))
+	})
+
+	c.Run("Non-Location Update Does Not Affect Tools", func(c *qt.C) {
+		// Create a user with a specific location
+		userLocation := NewLocation(41385063, 2173404) // Barcelona coordinates
+		user := &User{
+			Email:    "nonlocation@example.com",
+			Name:     "Non Location Test User",
+			Location: userLocation,
+			Salt:     "testsalt",
+			Active:   true,
+		}
+
+		userResult, err := userService.InsertUser(ctx, user)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert user for non-location test"))
+		userID := userResult.InsertedID.(primitive.ObjectID)
+
+		// Create a tool owned by the user
+		tool := &Tool{
+			ID:       9,
+			Title:    "Test Tool",
+			UserID:   userID,
+			Location: userLocation,
+		}
+
+		_, err = toolService.InsertTool(ctx, tool)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert tool for non-location test"))
+
+		// Update user name (not location)
+		update := bson.M{
+			"name": "Updated Name",
+		}
+
+		_, err = userService.UpdateUser(ctx, userID, update)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to update user name"))
+
+		// Verify that tool location was not changed
+		updatedTool, err := toolService.GetToolByID(ctx, 9)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get tool after non-location update"))
+		c.Assert(updatedTool.Location.Coordinates, qt.DeepEquals, userLocation.Coordinates, qt.Commentf("Tool location should not have changed"))
+
+		// Verify user name was updated
+		updatedUser, err := userService.GetUserByID(ctx, userID)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get updated user"))
+		c.Assert(updatedUser.Name, qt.Equals, "Updated Name", qt.Commentf("User name was not updated"))
+	})
+
+	c.Run("Obfuscated Location Updated", func(c *qt.C) {
+		// Create a user with a specific location
+		userLocation := NewLocation(41385063, 2173404) // Barcelona coordinates
+		user := &User{
+			Email:    "obfuscated@example.com",
+			Name:     "Obfuscated Test User",
+			Location: userLocation,
+			Salt:     "testsalt",
+			Active:   true,
+		}
+
+		userResult, err := userService.InsertUser(ctx, user)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert user for obfuscated test"))
+		userID := userResult.InsertedID.(primitive.ObjectID)
+
+		// Create a tool owned by the user
+		tool := &Tool{
+			ID:                 10,
+			Title:              "Test Tool",
+			UserID:             userID,
+			Location:           userLocation,
+			ObfuscatedLocation: ObfuscateLocation(userLocation, userID, "testsalt"),
+		}
+
+		_, err = toolService.InsertTool(ctx, tool)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to insert tool for obfuscated test"))
+
+		// Update user location
+		newLocation := NewLocation(48856614, 2352222) // Paris coordinates
+		newObfuscatedLocation := ObfuscateLocation(newLocation, userID, "testsalt")
+		update := bson.M{
+			"location":           newLocation,
+			"obfuscatedLocation": newObfuscatedLocation,
+		}
+
+		_, err = userService.UpdateUser(ctx, userID, update)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to update user location with obfuscated"))
+
+		// Verify that tool's obfuscated location was also updated
+		updatedTool, err := toolService.GetToolByID(ctx, 10)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get tool after obfuscated location update"))
+		c.Assert(updatedTool.Location.Coordinates, qt.DeepEquals, newLocation.Coordinates, qt.Commentf("Tool location not updated"))
+		c.Assert(updatedTool.ObfuscatedLocation.Coordinates, qt.DeepEquals, newObfuscatedLocation.Coordinates, qt.Commentf("Tool obfuscated location not updated"))
+	})
+}
+
+func TestLocationsEqual(t *testing.T) {
+	c := qt.New(t)
+
+	loc1 := NewLocation(41385063, 2173404)
+	loc2 := NewLocation(41385063, 2173404)
+	loc3 := NewLocation(40416775, -3703790)
+
+	c.Assert(locationsEqual(loc1, loc2), qt.Equals, true, qt.Commentf("Same locations should be equal"))
+	c.Assert(locationsEqual(loc1, loc3), qt.Equals, false, qt.Commentf("Different locations should not be equal"))
+
+	// Test with invalid coordinates
+	invalidLoc := DBLocation{Type: "Point", Coordinates: []float64{1.0}}
+	c.Assert(locationsEqual(loc1, invalidLoc), qt.Equals, false, qt.Commentf("Location with invalid coordinates should not be equal"))
+	c.Assert(locationsEqual(invalidLoc, loc1), qt.Equals, false, qt.Commentf("Invalid location should not be equal to valid location"))
+}

--- a/db/user_test.go
+++ b/db/user_test.go
@@ -355,7 +355,8 @@ func TestUpdateUser_LocationUpdate(t *testing.T) {
 		// Verify that tool with different location was not updated
 		updatedTool3, err := toolService.GetToolByID(ctx, 3)
 		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get updated tool3"))
-		c.Assert(updatedTool3.Location.Coordinates, qt.DeepEquals, differentLocation.Coordinates, qt.Commentf("Tool3 location should not have been updated"))
+		c.Assert(updatedTool3.Location.Coordinates, qt.DeepEquals, differentLocation.Coordinates,
+			qt.Commentf("Tool3 location should not have been updated"))
 	})
 
 	c.Run("Updates Nomadic Tools", func(c *qt.C) {
@@ -409,7 +410,8 @@ func TestUpdateUser_LocationUpdate(t *testing.T) {
 		// Verify that the nomadic tool location was updated
 		updatedTool, err := toolService.GetToolByID(ctx, 4)
 		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get updated nomadic tool"))
-		c.Assert(updatedTool.Location.Coordinates, qt.DeepEquals, newLocation.Coordinates, qt.Commentf("Nomadic tool location not updated"))
+		c.Assert(updatedTool.Location.Coordinates, qt.DeepEquals, newLocation.Coordinates,
+			qt.Commentf("Nomadic tool location not updated"))
 	})
 
 	c.Run("Mixed Scenario", func(c *qt.C) {
@@ -496,22 +498,26 @@ func TestUpdateUser_LocationUpdate(t *testing.T) {
 		// Verify owned tool with matching location was updated
 		updatedOwnedTool, err := toolService.GetToolByID(ctx, 5)
 		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get updated owned tool"))
-		c.Assert(updatedOwnedTool.Location.Coordinates, qt.DeepEquals, newLocation.Coordinates, qt.Commentf("Owned tool location not updated"))
+		c.Assert(updatedOwnedTool.Location.Coordinates, qt.DeepEquals, newLocation.Coordinates,
+			qt.Commentf("Owned tool location not updated"))
 
 		// Verify owned tool with different location was not updated
 		updatedOwnedToolDifferent, err := toolService.GetToolByID(ctx, 6)
 		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get owned tool different"))
-		c.Assert(updatedOwnedToolDifferent.Location.Coordinates, qt.DeepEquals, differentLocation.Coordinates, qt.Commentf("Owned tool different location should not have been updated"))
+		c.Assert(updatedOwnedToolDifferent.Location.Coordinates, qt.DeepEquals, differentLocation.Coordinates,
+			qt.Commentf("Owned tool different location should not have been updated"))
 
 		// Verify nomadic tool held by user1 was updated
 		updatedNomadicTool, err := toolService.GetToolByID(ctx, 7)
 		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get updated nomadic tool"))
-		c.Assert(updatedNomadicTool.Location.Coordinates, qt.DeepEquals, newLocation.Coordinates, qt.Commentf("Nomadic tool location not updated"))
+		c.Assert(updatedNomadicTool.Location.Coordinates, qt.DeepEquals, newLocation.Coordinates,
+			qt.Commentf("Nomadic tool location not updated"))
 
 		// Verify tool owned by different user was not updated
 		updatedOtherUserTool, err := toolService.GetToolByID(ctx, 8)
 		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get other user tool"))
-		c.Assert(updatedOtherUserTool.Location.Coordinates, qt.DeepEquals, userLocation.Coordinates, qt.Commentf("Other user tool location should not have been updated"))
+		c.Assert(updatedOtherUserTool.Location.Coordinates, qt.DeepEquals, userLocation.Coordinates,
+			qt.Commentf("Other user tool location should not have been updated"))
 	})
 
 	c.Run("Non-Location Update Does Not Affect Tools", func(c *qt.C) {
@@ -551,7 +557,8 @@ func TestUpdateUser_LocationUpdate(t *testing.T) {
 		// Verify that tool location was not changed
 		updatedTool, err := toolService.GetToolByID(ctx, 9)
 		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get tool after non-location update"))
-		c.Assert(updatedTool.Location.Coordinates, qt.DeepEquals, userLocation.Coordinates, qt.Commentf("Tool location should not have changed"))
+		c.Assert(updatedTool.Location.Coordinates, qt.DeepEquals, userLocation.Coordinates,
+			qt.Commentf("Tool location should not have changed"))
 
 		// Verify user name was updated
 		updatedUser, err := userService.GetUserByID(ctx, userID)
@@ -601,7 +608,8 @@ func TestUpdateUser_LocationUpdate(t *testing.T) {
 		updatedTool, err := toolService.GetToolByID(ctx, 10)
 		c.Assert(err, qt.IsNil, qt.Commentf("Failed to get tool after obfuscated location update"))
 		c.Assert(updatedTool.Location.Coordinates, qt.DeepEquals, newLocation.Coordinates, qt.Commentf("Tool location not updated"))
-		c.Assert(updatedTool.ObfuscatedLocation.Coordinates, qt.DeepEquals, newObfuscatedLocation.Coordinates, qt.Commentf("Tool obfuscated location not updated"))
+		c.Assert(updatedTool.ObfuscatedLocation.Coordinates, qt.DeepEquals, newObfuscatedLocation.Coordinates,
+			qt.Commentf("Tool obfuscated location not updated"))
 	})
 }
 
@@ -617,6 +625,8 @@ func TestLocationsEqual(t *testing.T) {
 
 	// Test with invalid coordinates
 	invalidLoc := DBLocation{Type: "Point", Coordinates: []float64{1.0}}
-	c.Assert(locationsEqual(loc1, invalidLoc), qt.Equals, false, qt.Commentf("Location with invalid coordinates should not be equal"))
-	c.Assert(locationsEqual(invalidLoc, loc1), qt.Equals, false, qt.Commentf("Invalid location should not be equal to valid location"))
+	c.Assert(locationsEqual(loc1, invalidLoc), qt.Equals, false,
+		qt.Commentf("Location with invalid coordinates should not be equal"))
+	c.Assert(locationsEqual(invalidLoc, loc1), qt.Equals, false,
+		qt.Commentf("Invalid location should not be equal to valid location"))
 }

--- a/test/user_test.go
+++ b/test/user_test.go
@@ -33,7 +33,8 @@ func TestUser(t *testing.T) {
 		}
 		err := json.Unmarshal(resp, &usersResp)
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, len(usersResp.Data.Users), qt.Equals, 5) // All users since we have less than page size
+		// All users since we have less than page size
+		qt.Assert(t, len(usersResp.Data.Users), qt.Equals, 5)
 
 		// Test unauthorized access
 		_, code = c.Request(http.MethodGet, "", nil, "users")
@@ -97,10 +98,13 @@ func TestUser(t *testing.T) {
 		qt.Assert(t, profileResp.Data.Email, qt.Equals, "user1@test.com")
 
 		// Verify new fields are present
-		qt.Assert(t, profileResp.Data.CreatedAt.IsZero(), qt.Equals, false, qt.Commentf("CreatedAt should not be zero"))
-		qt.Assert(t, profileResp.Data.LastSeen.IsZero(), qt.Equals, false, qt.Commentf("LastSeen should not be zero"))
+		qt.Assert(t, profileResp.Data.CreatedAt.IsZero(), qt.Equals, false,
+			qt.Commentf("CreatedAt should not be zero"))
+		qt.Assert(t, profileResp.Data.LastSeen.IsZero(), qt.Equals, false,
+			qt.Commentf("LastSeen should not be zero"))
 		qt.Assert(t, profileResp.Data.Bio, qt.Equals, "")
-		qt.Assert(t, profileResp.Data.RatingCount >= 0, qt.IsTrue, qt.Commentf("RatingCount should be >= 0"))
+		qt.Assert(t, profileResp.Data.RatingCount >= 0, qt.IsTrue,
+			qt.Commentf("RatingCount should be >= 0"))
 
 		// Try to get profile without auth
 		_, code = c.Request(http.MethodGet, "", nil, "profile")
@@ -152,7 +156,8 @@ func TestUser(t *testing.T) {
 		qt.Assert(t, profileResp.Data.Name, qt.Equals, "Updated User1")
 		qt.Assert(t, profileResp.Data.Community, qt.Equals, "Updated Community")
 		qt.Assert(t, profileResp.Data.Bio, qt.Equals, "This is my bio")
-		qt.Assert(t, profileResp.Data.LastSeen.IsZero(), qt.Equals, false, qt.Commentf("LastSeen should be updated"))
+		qt.Assert(t, profileResp.Data.LastSeen.IsZero(), qt.Equals, false,
+			qt.Commentf("LastSeen should be updated"))
 
 		// Get other user's profile
 		var user1ID string
@@ -382,7 +387,8 @@ func TestUserLocationUpdates(t *testing.T) {
 		// Create a nomadic tool owned by owner
 		nomadicToolID := createNomadicTool(ownerJWT, "Nomadic Tool", barcelonaLocation)
 
-		// Simulate the tool being picked up by holder (this would normally happen through booking flow)
+		// Simulate the tool being picked up by holder
+		// (this would normally happen through booking flow)
 		// For testing purposes, we'll need to create a booking and mark it as picked up
 		tomorrow := time.Now().Add(24 * time.Hour)
 		dayAfterTomorrow := time.Now().Add(48 * time.Hour)
@@ -414,7 +420,8 @@ func TestUserLocationUpdates(t *testing.T) {
 			}, "bookings", bookingID)
 		qt.Assert(t, code, qt.Equals, 200)
 
-		// Owner marks as picked up (this should set actualUserId and update tool location)
+		// Owner marks as picked up
+		// (this should set actualUserId and update tool location)
 		_, code = c.Request(http.MethodPut, ownerJWT,
 			&api.BookingStatusUpdate{
 				Status: "PICKED",
@@ -512,10 +519,14 @@ func TestUserLocationUpdates(t *testing.T) {
 
 		// Verify that the nomadic tool location DID NOT change (should remain at holder's location)
 		updatedTool := getTool(ownerJWT, nomadicToolID)
-		qt.Assert(t, updatedTool.Location.Latitude, qt.Equals, originalLat, qt.Commentf("Tool location should not change when owner moves"))
-		qt.Assert(t, updatedTool.Location.Longitude, qt.Equals, originalLon, qt.Commentf("Tool location should not change when owner moves"))
-		qt.Assert(t, updatedTool.ActualUserID, qt.Equals, holderID, qt.Commentf("Tool should still be held by holder"))
-		qt.Assert(t, updatedTool.UserID, qt.Equals, ownerID, qt.Commentf("Tool should still be owned by owner"))
+		qt.Assert(t, updatedTool.Location.Latitude, qt.Equals, originalLat,
+			qt.Commentf("Tool location should not change when owner moves"))
+		qt.Assert(t, updatedTool.Location.Longitude, qt.Equals, originalLon,
+			qt.Commentf("Tool location should not change when owner moves"))
+		qt.Assert(t, updatedTool.ActualUserID, qt.Equals, holderID,
+			qt.Commentf("Tool should still be held by holder"))
+		qt.Assert(t, updatedTool.UserID, qt.Equals, ownerID,
+			qt.Commentf("Tool should still be owned by owner"))
 	})
 
 	t.Run("Mixed Scenario - Owned and Nomadic Tools", func(t *testing.T) {

--- a/test/user_test.go
+++ b/test/user_test.go
@@ -2,8 +2,10 @@ package test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/emprius/emprius-app-backend/api"
 	"github.com/emprius/emprius-app-backend/test/utils"
@@ -249,5 +251,408 @@ func TestUser(t *testing.T) {
 		err = json.Unmarshal(resp, &refreshResp)
 		qt.Assert(t, err, qt.IsNil)
 		qt.Assert(t, refreshResp.Data.Token, qt.Not(qt.IsNil))
+	})
+}
+
+func TestUserLocationUpdates(t *testing.T) {
+	c := utils.NewTestService(t)
+
+	// Helper function to create a tool with specific location
+	createToolWithLocation := func(jwt string, title string, location api.Location) int64 {
+		resp, code := c.Request(http.MethodPost, jwt,
+			api.Tool{
+				Title:         title,
+				Description:   "Test tool",
+				Category:      1,
+				ToolValuation: uint64Ptr(10000),
+				Location:      location,
+			},
+			"tools",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var toolResp struct {
+			Data struct {
+				ID int64 `json:"id"`
+			} `json:"data"`
+		}
+		err := json.Unmarshal(resp, &toolResp)
+		qt.Assert(t, err, qt.IsNil)
+		return toolResp.Data.ID
+	}
+
+	// Helper function to get tool by ID
+	getTool := func(jwt string, toolID int64) api.Tool {
+		resp, code := c.Request(http.MethodGet, jwt, nil, "tools", fmt.Sprintf("%d", toolID))
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var toolResp struct {
+			Data api.Tool `json:"data"`
+		}
+		err := json.Unmarshal(resp, &toolResp)
+		qt.Assert(t, err, qt.IsNil)
+		return toolResp.Data
+	}
+
+	// Helper function to create nomadic tool
+	createNomadicTool := func(jwt string, title string, location api.Location) int64 {
+		isNomadic := true
+		resp, code := c.Request(http.MethodPost, jwt,
+			api.Tool{
+				Title:         title,
+				Description:   "Nomadic test tool",
+				Category:      1,
+				ToolValuation: uint64Ptr(10000),
+				Location:      location,
+				IsNomadic:     &isNomadic,
+			},
+			"tools",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var toolResp struct {
+			Data struct {
+				ID int64 `json:"id"`
+			} `json:"data"`
+		}
+		err := json.Unmarshal(resp, &toolResp)
+		qt.Assert(t, err, qt.IsNil)
+		return toolResp.Data.ID
+	}
+
+	t.Run("Location Update Updates Owned Tools", func(t *testing.T) {
+		// Create user with Barcelona location
+		barcelonaLocation := api.Location{
+			Latitude:  41385063, // Barcelona coordinates in microdegrees
+			Longitude: 2173404,
+		}
+
+		userJWT := c.RegisterAndLogin("location-test1@test.com", "LocationUser1", "password")
+
+		// Create tools owned by the user with the same location
+		tool1ID := createToolWithLocation(userJWT, "Tool 1", barcelonaLocation)
+		tool2ID := createToolWithLocation(userJWT, "Tool 2", barcelonaLocation)
+
+		// Create a tool with different location (should not be updated)
+		madridLocation := api.Location{
+			Latitude:  40416775, // Madrid coordinates in microdegrees
+			Longitude: -3703790,
+		}
+		tool3ID := createToolWithLocation(userJWT, "Tool 3", madridLocation)
+
+		// Update user location to Paris
+		parisLocation := api.Location{
+			Latitude:  48856614, // Paris coordinates in microdegrees
+			Longitude: 2352222,
+		}
+
+		_, code := c.Request(http.MethodPost, userJWT,
+			api.UserProfile{
+				Location: &parisLocation,
+			},
+			"profile",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Verify that tools with matching location were updated
+		updatedTool1 := getTool(userJWT, tool1ID)
+		qt.Assert(t, updatedTool1.Location.Latitude, qt.Equals, parisLocation.Latitude)
+		qt.Assert(t, updatedTool1.Location.Longitude, qt.Equals, parisLocation.Longitude)
+
+		updatedTool2 := getTool(userJWT, tool2ID)
+		qt.Assert(t, updatedTool2.Location.Latitude, qt.Equals, parisLocation.Latitude)
+		qt.Assert(t, updatedTool2.Location.Longitude, qt.Equals, parisLocation.Longitude)
+
+		// Verify that tool with different location was not updated
+		updatedTool3 := getTool(userJWT, tool3ID)
+		qt.Assert(t, updatedTool3.Location.Latitude, qt.Equals, madridLocation.Latitude)
+		qt.Assert(t, updatedTool3.Location.Longitude, qt.Equals, madridLocation.Longitude)
+	})
+
+	t.Run("Location Update Updates Nomadic Tools Held By User", func(t *testing.T) {
+		// Create two users with Barcelona location
+		barcelonaLocation := api.Location{
+			Latitude:  41385063,
+			Longitude: 2173404,
+		}
+
+		ownerJWT, _ := c.RegisterAndLoginWithID("nomadic-owner@test.com", "NomadicOwner", "password")
+		holderJWT, holderID := c.RegisterAndLoginWithID("nomadic-holder@test.com", "NomadicHolder", "password")
+
+		// Create a nomadic tool owned by owner
+		nomadicToolID := createNomadicTool(ownerJWT, "Nomadic Tool", barcelonaLocation)
+
+		// Simulate the tool being picked up by holder (this would normally happen through booking flow)
+		// For testing purposes, we'll need to create a booking and mark it as picked up
+		tomorrow := time.Now().Add(24 * time.Hour)
+		dayAfterTomorrow := time.Now().Add(48 * time.Hour)
+
+		// Create booking
+		resp, code := c.Request(http.MethodPost, holderJWT,
+			api.CreateBookingRequest{
+				ToolID:    fmt.Sprintf("%d", nomadicToolID),
+				StartDate: tomorrow.Unix(),
+				EndDate:   dayAfterTomorrow.Unix(),
+				Contact:   "test@example.com",
+				Comments:  "Test booking for nomadic tool",
+			},
+			"bookings",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var bookingResp struct {
+			Data api.BookingResponse `json:"data"`
+		}
+		err := json.Unmarshal(resp, &bookingResp)
+		qt.Assert(t, err, qt.IsNil)
+		bookingID := bookingResp.Data.ID
+
+		// Owner accepts the booking
+		_, code = c.Request(http.MethodPut, ownerJWT,
+			&api.BookingStatusUpdate{
+				Status: "ACCEPTED",
+			}, "bookings", bookingID)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Owner marks as picked up (this should set actualUserId and update tool location)
+		_, code = c.Request(http.MethodPut, ownerJWT,
+			&api.BookingStatusUpdate{
+				Status: "PICKED",
+			}, "bookings", bookingID)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Now update holder's location to Paris
+		parisLocation := api.Location{
+			Latitude:  48856614,
+			Longitude: 2352222,
+		}
+
+		_, code = c.Request(http.MethodPost, holderJWT,
+			api.UserProfile{
+				Location: &parisLocation,
+			},
+			"profile",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Verify that the nomadic tool location was updated to holder's new location
+		updatedTool := getTool(ownerJWT, nomadicToolID)
+		qt.Assert(t, updatedTool.Location.Latitude, qt.Equals, parisLocation.Latitude)
+		qt.Assert(t, updatedTool.Location.Longitude, qt.Equals, parisLocation.Longitude)
+		qt.Assert(t, updatedTool.ActualUserID, qt.Equals, holderID)
+	})
+
+	t.Run("Nomadic Tool Owner Location Change Does Not Update Tool", func(t *testing.T) {
+		// Create two users with Barcelona location
+		barcelonaLocation := api.Location{
+			Latitude:  41385063,
+			Longitude: 2173404,
+		}
+
+		ownerJWT, ownerID := c.RegisterAndLoginWithID("nomadic-owner2@test.com", "NomadicOwner2", "password")
+		holderJWT, holderID := c.RegisterAndLoginWithID("nomadic-holder2@test.com", "NomadicHolder2", "password")
+
+		// Create a nomadic tool owned by owner
+		nomadicToolID := createNomadicTool(ownerJWT, "Nomadic Tool 2", barcelonaLocation)
+
+		// Create booking and simulate pickup
+		tomorrow := time.Now().Add(24 * time.Hour)
+		dayAfterTomorrow := time.Now().Add(48 * time.Hour)
+
+		resp, code := c.Request(http.MethodPost, holderJWT,
+			api.CreateBookingRequest{
+				ToolID:    fmt.Sprintf("%d", nomadicToolID),
+				StartDate: tomorrow.Unix(),
+				EndDate:   dayAfterTomorrow.Unix(),
+				Contact:   "test@example.com",
+				Comments:  "Test booking for nomadic tool",
+			},
+			"bookings",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var bookingResp struct {
+			Data api.BookingResponse `json:"data"`
+		}
+		err := json.Unmarshal(resp, &bookingResp)
+		qt.Assert(t, err, qt.IsNil)
+		bookingID := bookingResp.Data.ID
+
+		// Owner accepts and marks as picked up
+		_, code = c.Request(http.MethodPut, ownerJWT,
+			&api.BookingStatusUpdate{
+				Status: "ACCEPTED",
+			}, "bookings", bookingID)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		_, code = c.Request(http.MethodPut, ownerJWT,
+			&api.BookingStatusUpdate{
+				Status: "PICKED",
+			}, "bookings", bookingID)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Get tool location before owner location change
+		toolBeforeUpdate := getTool(ownerJWT, nomadicToolID)
+		originalLat := toolBeforeUpdate.Location.Latitude
+		originalLon := toolBeforeUpdate.Location.Longitude
+
+		// Now update OWNER's location to Paris (not the holder)
+		parisLocation := api.Location{
+			Latitude:  48856614,
+			Longitude: 2352222,
+		}
+
+		_, code = c.Request(http.MethodPost, ownerJWT,
+			api.UserProfile{
+				Location: &parisLocation,
+			},
+			"profile",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Verify that the nomadic tool location DID NOT change (should remain at holder's location)
+		updatedTool := getTool(ownerJWT, nomadicToolID)
+		qt.Assert(t, updatedTool.Location.Latitude, qt.Equals, originalLat, qt.Commentf("Tool location should not change when owner moves"))
+		qt.Assert(t, updatedTool.Location.Longitude, qt.Equals, originalLon, qt.Commentf("Tool location should not change when owner moves"))
+		qt.Assert(t, updatedTool.ActualUserID, qt.Equals, holderID, qt.Commentf("Tool should still be held by holder"))
+		qt.Assert(t, updatedTool.UserID, qt.Equals, ownerID, qt.Commentf("Tool should still be owned by owner"))
+	})
+
+	t.Run("Mixed Scenario - Owned and Nomadic Tools", func(t *testing.T) {
+		// Create users with Barcelona location
+		barcelonaLocation := api.Location{
+			Latitude:  41385063,
+			Longitude: 2173404,
+		}
+
+		user1JWT, user1ID := c.RegisterAndLoginWithID("mixed-user1@test.com", "MixedUser1", "password")
+		user2JWT, _ := c.RegisterAndLoginWithID("mixed-user2@test.com", "MixedUser2", "password")
+
+		// Create various tools
+		madridLocation := api.Location{
+			Latitude:  40416775,
+			Longitude: -3703790,
+		}
+
+		// Tool owned by user1 with matching location (should be updated)
+		ownedToolID := createToolWithLocation(user1JWT, "Owned Tool", barcelonaLocation)
+
+		// Tool owned by user1 with different location (should not be updated)
+		ownedToolDifferentID := createToolWithLocation(user1JWT, "Owned Tool Different", madridLocation)
+
+		// Create nomadic tool owned by user2 but held by user1
+		nomadicToolID := createNomadicTool(user2JWT, "Nomadic Tool", barcelonaLocation)
+
+		// Simulate nomadic tool pickup by user1
+		tomorrow := time.Now().Add(24 * time.Hour)
+		dayAfterTomorrow := time.Now().Add(48 * time.Hour)
+
+		resp, code := c.Request(http.MethodPost, user1JWT,
+			api.CreateBookingRequest{
+				ToolID:    fmt.Sprintf("%d", nomadicToolID),
+				StartDate: tomorrow.Unix(),
+				EndDate:   dayAfterTomorrow.Unix(),
+				Contact:   "test@example.com",
+				Comments:  "Test booking",
+			},
+			"bookings",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var bookingResp struct {
+			Data api.BookingResponse `json:"data"`
+		}
+		err := json.Unmarshal(resp, &bookingResp)
+		qt.Assert(t, err, qt.IsNil)
+		bookingID := bookingResp.Data.ID
+
+		// Accept and mark as picked up
+		_, code = c.Request(http.MethodPut, user2JWT,
+			&api.BookingStatusUpdate{
+				Status: "ACCEPTED",
+			}, "bookings", bookingID)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		_, code = c.Request(http.MethodPut, user2JWT,
+			&api.BookingStatusUpdate{
+				Status: "PICKED",
+			}, "bookings", bookingID)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Tool owned by different user (should not be updated)
+		otherUserToolID := createToolWithLocation(user2JWT, "Other User Tool", barcelonaLocation)
+
+		// Update user1's location to Paris
+		parisLocation := api.Location{
+			Latitude:  48856614,
+			Longitude: 2352222,
+		}
+
+		_, code = c.Request(http.MethodPost, user1JWT,
+			api.UserProfile{
+				Location: &parisLocation,
+			},
+			"profile",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Verify owned tool with matching location was updated
+		updatedOwnedTool := getTool(user1JWT, ownedToolID)
+		qt.Assert(t, updatedOwnedTool.Location.Latitude, qt.Equals, parisLocation.Latitude)
+		qt.Assert(t, updatedOwnedTool.Location.Longitude, qt.Equals, parisLocation.Longitude)
+
+		// Verify owned tool with different location was not updated
+		updatedOwnedToolDifferent := getTool(user1JWT, ownedToolDifferentID)
+		qt.Assert(t, updatedOwnedToolDifferent.Location.Latitude, qt.Equals, madridLocation.Latitude)
+		qt.Assert(t, updatedOwnedToolDifferent.Location.Longitude, qt.Equals, madridLocation.Longitude)
+
+		// Verify nomadic tool held by user1 was updated
+		updatedNomadicTool := getTool(user2JWT, nomadicToolID)
+		qt.Assert(t, updatedNomadicTool.Location.Latitude, qt.Equals, parisLocation.Latitude)
+		qt.Assert(t, updatedNomadicTool.Location.Longitude, qt.Equals, parisLocation.Longitude)
+		qt.Assert(t, updatedNomadicTool.ActualUserID, qt.Equals, user1ID)
+
+		// Verify tool owned by different user was not updated
+		updatedOtherUserTool := getTool(user2JWT, otherUserToolID)
+		qt.Assert(t, updatedOtherUserTool.Location.Latitude, qt.Equals, barcelonaLocation.Latitude)
+		qt.Assert(t, updatedOtherUserTool.Location.Longitude, qt.Equals, barcelonaLocation.Longitude)
+	})
+
+	t.Run("Non-Location Update Does Not Affect Tools", func(t *testing.T) {
+		// Create user with Barcelona location
+		barcelonaLocation := api.Location{
+			Latitude:  41385063,
+			Longitude: 2173404,
+		}
+
+		userJWT := c.RegisterAndLogin("non-location-test@test.com", "NonLocationUser", "password")
+
+		// Create a tool owned by the user
+		toolID := createToolWithLocation(userJWT, "Test Tool", barcelonaLocation)
+
+		// Update user name (not location)
+		_, code := c.Request(http.MethodPost, userJWT,
+			api.UserProfile{
+				Name: "Updated Name",
+			},
+			"profile",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Verify that tool location was not changed
+		updatedTool := getTool(userJWT, toolID)
+		qt.Assert(t, updatedTool.Location.Latitude, qt.Equals, barcelonaLocation.Latitude)
+		qt.Assert(t, updatedTool.Location.Longitude, qt.Equals, barcelonaLocation.Longitude)
+
+		// Verify user name was updated
+		resp, code := c.Request(http.MethodGet, userJWT, nil, "profile")
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var profileResp struct {
+			Data *api.User `json:"data"`
+		}
+		err := json.Unmarshal(resp, &profileResp)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, profileResp.Data.Name, qt.Equals, "Updated Name")
 	})
 }

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -157,13 +157,23 @@ func (s *TestService) Request(method, jwt string, jsonBody any, urlPath ...strin
 }
 
 // RegisterAndLogin registers a new user and returns the JWT token
-func (s *TestService) RegisterAndLogin(email, name, password string) string {
-	jwt, _ := s.RegisterAndLoginWithID(email, name, password)
+func (s *TestService) RegisterAndLogin(email, name, password string, location ...*api.Location) string {
+	jwt, _ := s.RegisterAndLoginWithID(email, name, password, location...)
 	return jwt
 }
 
 // RegisterAndLoginWithID registers a new user and returns the JWT token and user ID
-func (s *TestService) RegisterAndLoginWithID(email, name, password string) (string, string) {
+func (s *TestService) RegisterAndLoginWithID(email, name, password string, location ...*api.Location) (string, string) {
+	// Set default location if none provided
+	defaultLocation := &api.Location{
+		Latitude:  41695384, // 41.695384 * 1e6
+		Longitude: 2492793,  // 2.492793 * 1e6
+	}
+	loc := defaultLocation
+	if len(location) > 0 && location[0] != nil {
+		loc = location[0]
+	}
+
 	// Register
 	_, code := s.Request(http.MethodPost, "",
 		&api.Register{
@@ -173,10 +183,7 @@ func (s *TestService) RegisterAndLoginWithID(email, name, password string) (stri
 				Name:      name,
 				Community: "testCommunity",
 				Password:  password,
-				Location: &api.Location{
-					Latitude:  41695384, // 41.695384 * 1e6
-					Longitude: 2492793,  // 2.492793 * 1e6
-				},
+				Location:  loc,
 			},
 		},
 		"register",


### PR DESCRIPTION
Fixes https://github.com/emprius/emprius-app-backend/issues/110
Fixes #83 

- Generates random password salt for each user to be used as salt for location obfuscation
- Uses the user random salt to generate the obfucated location
- For nomadic tools show real location if the user is the owner and no actual user or is the actual user. 
- Updates tool location when user updates its location where the user is the owner and the user or is the actual user