### PR TITLE
Protect community routes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,15 @@
 name: Main
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - main
+      - stage
+      - 'release**'
+  push:
+    branches:
+      - main
+      - stage
+      - 'release**'
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -40,7 +50,7 @@ jobs:
   docker-release:
     runs-on: ubuntu-latest
     needs: [test, lint]
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stage' ||  startsWith(github.ref, 'refs/heads/release')
+    if: github.event_name == 'push'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -53,13 +63,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Get short commit sha
         id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Get short branch name
         id: var
         shell: bash
         # Grab the short branch name, convert slashes to dashes
-        run: |
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | tr '/' '-' )"
+        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/} | tr '/' '-')" >> $GITHUB_OUTPUT
       - name: Push to ghcr.io
         uses: docker/build-push-action@v5
         with:

--- a/api/communities.go
+++ b/api/communities.go
@@ -173,24 +173,8 @@ func (a *API) getCommunityHandler(r *Request) (interface{}, error) {
 		return nil, ErrInvalidRequestBodyData.WithErr(err)
 	}
 
-	// Get user ID
-	userID, err := primitive.ObjectIDFromHex(r.UserID)
-	if err != nil {
-		return nil, ErrInvalidUserID.WithErr(err)
-	}
-
-	// Check if user is a member of the community
-	ctx := r.Context.Request.Context()
-	isMember, err := a.database.CommunityService.IsUserMemberOfCommunity(ctx, userID, communityID)
-	if err != nil {
-		return nil, ErrInternalServerError.WithErr(err)
-	}
-	if !isMember {
-		return nil, ErrCommunityNotFound.WithErr(fmt.Errorf("community not found"))
-	}
-
 	// Get community with member count and tool count
-	community, membersCount, toolsCount, err := a.database.CommunityService.GetCommunityWithMemberCount(ctx, communityID)
+	community, membersCount, toolsCount, err := a.database.CommunityService.GetCommunityWithMemberCount(r.Context.Request.Context(), communityID)
 	if err != nil {
 		return nil, ErrCommunityNotFound.WithErr(err)
 	}
@@ -316,22 +300,6 @@ func (a *API) getCommunityUsersHandler(r *Request) (interface{}, error) {
 		return nil, ErrInvalidRequestBodyData.WithErr(err)
 	}
 
-	// Get user ID
-	userID, err := primitive.ObjectIDFromHex(r.UserID)
-	if err != nil {
-		return nil, ErrInvalidUserID.WithErr(err)
-	}
-
-	// Check if user is a member of the community
-	ctx := r.Context.Request.Context()
-	isMember, err := a.database.CommunityService.IsUserMemberOfCommunity(ctx, userID, communityID)
-	if err != nil {
-		return nil, ErrInternalServerError.WithErr(err)
-	}
-	if !isMember {
-		return nil, ErrCommunityNotFound.WithErr(fmt.Errorf("community not found"))
-	}
-
 	// Get page from query parameters
 	page, pageSize, err := r.Context.GetPaginationParams()
 	if err != nil {
@@ -341,7 +309,7 @@ func (a *API) getCommunityUsersHandler(r *Request) (interface{}, error) {
 	term := *r.Context.GetSearchTerm()
 
 	// Get community users
-	users, total, err := a.database.CommunityService.GetCommunityUsers(ctx, communityID, page, term)
+	users, total, err := a.database.CommunityService.GetCommunityUsers(r.Context.Request.Context(), communityID, page, term)
 	if err != nil {
 		return nil, ErrInternalServerError.WithErr(err)
 	}
@@ -765,7 +733,7 @@ func (a *API) getCommunityToolsHandler(r *Request) (interface{}, error) {
 		return nil, ErrInternalServerError.WithErr(err)
 	}
 	if !isMember {
-		return nil, ErrCommunityNotFound.WithErr(fmt.Errorf("community not found"))
+		return nil, ErrNotMember
 	}
 
 	// Get pagination parameters

--- a/api/communities.go
+++ b/api/communities.go
@@ -186,7 +186,7 @@ func (a *API) getCommunityHandler(r *Request) (interface{}, error) {
 		return nil, ErrInternalServerError.WithErr(err)
 	}
 	if !isMember {
-		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user is not a member of this community"))
+		return nil, ErrCommunityNotFound.WithErr(fmt.Errorf("community not found"))
 	}
 
 	// Get community with member count and tool count
@@ -238,7 +238,7 @@ func (a *API) updateCommunityHandler(r *Request) (interface{}, error) {
 	}
 
 	if community.OwnerID != userID {
-		return nil, ErrUnauthorized.WithErr(fmt.Errorf("only the community owner can update the community"))
+		return nil, ErrForbidden.WithErr(fmt.Errorf("only the community owner can update the community"))
 	}
 
 	// Update community
@@ -291,7 +291,7 @@ func (a *API) deleteCommunityHandler(r *Request) (interface{}, error) {
 	}
 
 	if community.OwnerID != userID {
-		return nil, ErrUnauthorized.WithErr(fmt.Errorf("only the community owner can delete the community"))
+		return nil, ErrForbidden.WithErr(fmt.Errorf("only the community owner can delete the community"))
 	}
 
 	// Delete community
@@ -329,7 +329,7 @@ func (a *API) getCommunityUsersHandler(r *Request) (interface{}, error) {
 		return nil, ErrInternalServerError.WithErr(err)
 	}
 	if !isMember {
-		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user is not a member of this community"))
+		return nil, ErrCommunityNotFound.WithErr(fmt.Errorf("community not found"))
 	}
 
 	// Get page from query parameters
@@ -470,7 +470,7 @@ func (a *API) leaveCommunityHandler(r *Request) (interface{}, error) {
 			}
 
 			if community.OwnerID != authUserID {
-				return nil, ErrUnauthorized.WithErr(fmt.Errorf("only the community owner can remove other users"))
+				return nil, ErrForbidden.WithErr(fmt.Errorf("only the community owner can remove other users"))
 			}
 		}
 	} else {
@@ -765,7 +765,7 @@ func (a *API) getCommunityToolsHandler(r *Request) (interface{}, error) {
 		return nil, ErrInternalServerError.WithErr(err)
 	}
 	if !isMember {
-		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user is not a member of this community"))
+		return nil, ErrCommunityNotFound.WithErr(fmt.Errorf("community not found"))
 	}
 
 	// Get pagination parameters

--- a/api/communities.go
+++ b/api/communities.go
@@ -173,8 +173,23 @@ func (a *API) getCommunityHandler(r *Request) (interface{}, error) {
 		return nil, ErrInvalidRequestBodyData.WithErr(err)
 	}
 
-	// Get community with member count and tool count
+	// Get user ID
+	userID, err := primitive.ObjectIDFromHex(r.UserID)
+	if err != nil {
+		return nil, ErrInvalidUserID.WithErr(err)
+	}
+
+	// Check if user is a member of the community
 	ctx := r.Context.Request.Context()
+	isMember, err := a.database.CommunityService.IsUserMemberOfCommunity(ctx, userID, communityID)
+	if err != nil {
+		return nil, ErrInternalServerError.WithErr(err)
+	}
+	if !isMember {
+		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user is not a member of this community"))
+	}
+
+	// Get community with member count and tool count
 	community, membersCount, toolsCount, err := a.database.CommunityService.GetCommunityWithMemberCount(ctx, communityID)
 	if err != nil {
 		return nil, ErrCommunityNotFound.WithErr(err)
@@ -301,6 +316,22 @@ func (a *API) getCommunityUsersHandler(r *Request) (interface{}, error) {
 		return nil, ErrInvalidRequestBodyData.WithErr(err)
 	}
 
+	// Get user ID
+	userID, err := primitive.ObjectIDFromHex(r.UserID)
+	if err != nil {
+		return nil, ErrInvalidUserID.WithErr(err)
+	}
+
+	// Check if user is a member of the community
+	ctx := r.Context.Request.Context()
+	isMember, err := a.database.CommunityService.IsUserMemberOfCommunity(ctx, userID, communityID)
+	if err != nil {
+		return nil, ErrInternalServerError.WithErr(err)
+	}
+	if !isMember {
+		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user is not a member of this community"))
+	}
+
 	// Get page from query parameters
 	page, pageSize, err := r.Context.GetPaginationParams()
 	if err != nil {
@@ -310,7 +341,7 @@ func (a *API) getCommunityUsersHandler(r *Request) (interface{}, error) {
 	term := *r.Context.GetSearchTerm()
 
 	// Get community users
-	users, total, err := a.database.CommunityService.GetCommunityUsers(r.Context.Request.Context(), communityID, page, term)
+	users, total, err := a.database.CommunityService.GetCommunityUsers(ctx, communityID, page, term)
 	if err != nil {
 		return nil, ErrInternalServerError.WithErr(err)
 	}
@@ -721,13 +752,20 @@ func (a *API) getCommunityToolsHandler(r *Request) (interface{}, error) {
 		return nil, ErrInvalidRequestBodyData.WithErr(err)
 	}
 
-	// Check if community exists
-	exists, err := a.database.CommunityService.CommunityExists(r.Context.Request.Context(), communityID)
+	// Get user ID
+	userID, err := primitive.ObjectIDFromHex(r.UserID)
+	if err != nil {
+		return nil, ErrInvalidUserID.WithErr(err)
+	}
+
+	// Check if user is a member of the community
+	ctx := r.Context.Request.Context()
+	isMember, err := a.database.CommunityService.IsUserMemberOfCommunity(ctx, userID, communityID)
 	if err != nil {
 		return nil, ErrInternalServerError.WithErr(err)
 	}
-	if !exists {
-		return nil, ErrCommunityNotFound.WithErr(fmt.Errorf("community with id %s not found", communityIDStr))
+	if !isMember {
+		return nil, ErrUnauthorized.WithErr(fmt.Errorf("user is not a member of this community"))
 	}
 
 	// Get pagination parameters
@@ -741,7 +779,7 @@ func (a *API) getCommunityToolsHandler(r *Request) (interface{}, error) {
 
 	// Get paginated tools for the community
 	dbTools, total, err := a.database.CommunityService.GetCommunityToolsPaginated(
-		r.Context.Request.Context(),
+		ctx,
 		communityID,
 		page,
 		pageSize,

--- a/api/communities_test.go
+++ b/api/communities_test.go
@@ -257,7 +257,7 @@ func TestGetCommunityToolsHandler(t *testing.T) {
 		// Call handler
 		_, err := api.getCommunityToolsHandler(apiReq)
 		c.Assert(err, quicktest.Not(quicktest.IsNil))
-		c.Assert(err.Error(), quicktest.Contains, "not found")
+		c.Assert(err.Error(), quicktest.Contains, "Not member of the community")
 	})
 
 	t.Run("case insensitive search", func(t *testing.T) {

--- a/api/errors.go
+++ b/api/errors.go
@@ -88,15 +88,17 @@ var (
 		Code:    http.StatusBadRequest,
 		Message: "invalid rating value",
 	}
-
 	ErrInvalidBookingStatus = &HTTPError{
 		Code:    http.StatusBadRequest,
 		Message: "invalid booking status",
 	}
-
 	ErrAlreadyRated = &HTTPError{
 		Code:    http.StatusForbidden,
 		Message: "booking already rated",
+	}
+	ErrNotMember = &HTTPError{
+		Code:    http.StatusForbidden,
+		Message: "Not member of the community",
 	}
 )
 

--- a/api/errors.go
+++ b/api/errors.go
@@ -48,6 +48,10 @@ var (
 		Code:    http.StatusBadRequest,
 		Message: "invalid credentials",
 	}
+	ErrForbidden = &HTTPError{
+		Code:    http.StatusForbidden,
+		Message: "unauthorized access",
+	}
 )
 
 // Request validation errors

--- a/api/tools.go
+++ b/api/tools.go
@@ -481,9 +481,16 @@ func (a *API) getUserTools(r *Request, id primitive.ObjectID) (interface{}, erro
 		}
 	}
 
-	// Get paginated tools with access control
-	tools, total, err := a.database.ToolService.GetToolsByUserIDPaginated(
-		context.Background(), id, page, pageSize, searchTerm, showOwnTools, showHeldTools,
+	// Get requesting user ID
+	requestingUserID, err := primitive.ObjectIDFromHex(r.UserID)
+	if err != nil {
+		return nil, ErrInvalidUserID.WithErr(err)
+	}
+
+	// Get paginated tools with community access control
+	// This will filter out tools from communities the requesting user is not a member of
+	tools, total, err := a.database.ToolService.GetToolsByUserIDWithAccessControl(
+		context.Background(), id, requestingUserID, page, pageSize, searchTerm, showOwnTools, showHeldTools,
 	)
 	if err != nil {
 		return nil, err

--- a/db/community.go
+++ b/db/community.go
@@ -127,6 +127,26 @@ func (s *CommunityService) GetCommunity(ctx context.Context, id primitive.Object
 	return &community, nil
 }
 
+// IsUserMemberOfCommunity checks if a user is a member of a community
+func (s *CommunityService) IsUserMemberOfCommunity(
+	ctx context.Context,
+	userID primitive.ObjectID,
+	communityID primitive.ObjectID,
+) (bool, error) {
+	// Query the users collection to check if the user has this community in their communities array
+	filter := bson.M{
+		"_id":            userID,
+		"communities.id": communityID,
+	}
+
+	count, err := s.UserService.Collection.CountDocuments(ctx, filter)
+	if err != nil {
+		return false, err
+	}
+
+	return count > 0, nil
+}
+
 // UpdateCommunity updates a community
 func (s *CommunityService) UpdateCommunity(ctx context.Context, id primitive.ObjectID, name string, image types.HexBytes) error {
 	update := bson.M{

--- a/db/tool.go
+++ b/db/tool.go
@@ -133,10 +133,73 @@ func (s *ToolService) GetToolByID(ctx context.Context, id int64) (*Tool, error) 
 	return &tool, nil
 }
 
-// GetToolByIDWithAccessControl retrieves a Tool by its ID with access control for inactive users.
-// Allows access to tools from inactive users if:
-// 1. The requesting user is the tool owner, OR
-// 2. The requesting user was involved in any booking request for this tool
+// buildCommunityAccessStages creates aggregation stages for community membership checking.
+// Returns stages that check if requesting user has access based on:
+// 1. Tool has no communities (public tool), OR
+// 2. User is a member of at least one of the tool's communities
+func buildCommunityAccessStages(requestingUserID primitive.ObjectID) []bson.D {
+	return []bson.D{
+		// Join with users collection to get requesting user's communities
+		{
+			{Key: "$lookup", Value: bson.D{
+				{Key: "from", Value: "users"},
+				{Key: "pipeline", Value: bson.A{
+					bson.D{{Key: "$match", Value: bson.D{
+						{Key: "$expr", Value: bson.D{
+							{Key: "$eq", Value: bson.A{"$_id", requestingUserID}},
+						}},
+					}}},
+					bson.D{{Key: "$project", Value: bson.D{
+						{Key: "communityIds", Value: "$communities.id"},
+					}}},
+				}},
+				{Key: "as", Value: "requestingUser"},
+			}},
+		},
+		// Add field to check if user is member of any tool community
+		{
+			{Key: "$addFields", Value: bson.D{
+				{Key: "userCommunities", Value: bson.D{
+					{Key: "$arrayElemAt", Value: bson.A{"$requestingUser.communityIds", 0}},
+				}},
+				{Key: "toolCommunitiesArray", Value: bson.D{
+					{Key: "$ifNull", Value: bson.A{"$communities", bson.A{}}},
+				}},
+			}},
+		},
+		// Calculate if there's any common community
+		{
+			{Key: "$addFields", Value: bson.D{
+				{Key: "hasCommonCommunity", Value: bson.D{
+					{Key: "$cond", Value: bson.A{
+						// If tool has no communities, it's public (allow access)
+						bson.D{{Key: "$eq", Value: bson.A{
+							bson.D{{Key: "$size", Value: "$toolCommunitiesArray"}},
+							0,
+						}}},
+						true,
+						// Otherwise check if there's any intersection
+						bson.D{{Key: "$gt", Value: bson.A{
+							bson.D{{Key: "$size", Value: bson.D{
+								{Key: "$setIntersection", Value: bson.A{
+									bson.D{{Key: "$ifNull", Value: bson.A{"$userCommunities", bson.A{}}}},
+									"$toolCommunitiesArray",
+								}},
+							}}},
+							0,
+						}}},
+					}},
+				}},
+			}},
+		},
+	}
+}
+
+// GetToolByIDWithAccessControl retrieves a Tool by its ID with access control.
+// Allows access to tools if:
+// 1. Tool owner is active AND (tool is public OR user is member of tool's community), OR
+// 2. Requesting user is the tool owner (always allowed), OR
+// 3. Requesting user was involved in any booking request for this tool (always allowed)
 func (s *ToolService) GetToolByIDWithAccessControl(
 	ctx context.Context,
 	id int64,
@@ -145,7 +208,7 @@ func (s *ToolService) GetToolByIDWithAccessControl(
 	// Convert tool ID to string for booking lookup
 	toolIDStr := strconv.FormatInt(id, 10)
 
-	// Use aggregation to join with users and bookings collections and check access control
+	// Build the aggregation pipeline
 	pipeline := mongo.Pipeline{
 		// Stage 1: Match the specific tool
 		bson.D{{Key: "$match", Value: bson.M{"_id": id}}},
@@ -180,24 +243,33 @@ func (s *ToolService) GetToolByIDWithAccessControl(
 				{Key: "as", Value: "userBookings"},
 			}},
 		},
-		// Stage 4: Filter based on access control rules
-		bson.D{
-			{Key: "$match", Value: bson.D{
-				{Key: "$or", Value: bson.A{
-					// Allow if tool owner is active
-					bson.D{{Key: "owner.active", Value: true}},
-					// Allow if requesting user is the tool owner
-					bson.D{{Key: "userId", Value: requestingUserID}},
-					// Allow if requesting user was involved in any booking for this tool
-					bson.D{{Key: "userBookings", Value: bson.D{{Key: "$ne", Value: bson.A{}}}}},
-				}},
-			}},
-		},
-		// Stage 5: Remove the temporary fields from output
-		bson.D{
-			{Key: "$unset", Value: bson.A{"owner", "userBookings"}},
-		},
 	}
+
+	// Stage 4 & 5: Add community access checking stages
+	communityStages := buildCommunityAccessStages(requestingUserID)
+	pipeline = append(pipeline, communityStages...)
+
+	// Stage 6: Filter based on access control rules
+	pipeline = append(pipeline, bson.D{
+		{Key: "$match", Value: bson.D{
+			{Key: "$or", Value: bson.A{
+				// Allow if tool owner is active AND user has community access
+				bson.D{
+					{Key: "owner.active", Value: true},
+					{Key: "hasCommonCommunity", Value: true},
+				},
+				// Allow if requesting user is the tool owner
+				bson.D{{Key: "userId", Value: requestingUserID}},
+				// Allow if requesting user was involved in any booking for this tool
+				bson.D{{Key: "userBookings", Value: bson.D{{Key: "$ne", Value: bson.A{}}}}},
+			}},
+		}},
+	})
+
+	// Stage 7: Remove the temporary fields from output
+	pipeline = append(pipeline, bson.D{
+		{Key: "$unset", Value: bson.A{"owner", "userBookings", "requestingUser", "userCommunities", "hasCommonCommunity"}},
+	})
 
 	cursor, err := s.Collection.Aggregate(ctx, pipeline)
 	if err != nil {
@@ -275,24 +347,35 @@ func (s *ToolService) GetAllTools(ctx context.Context) ([]*Tool, error) {
 	return tools, nil
 }
 
-// GetToolsByUserIDPaginated retrieves tools owned and/or held by a user with pagination and optional search term filtering
-func (s *ToolService) GetToolsByUserIDPaginated(
+// GetToolsByUserIDWithAccessControl retrieves tools owned and/or held by a user with pagination,
+// search term filtering, and community access control.
+// This method filters out tools that belong to communities the requesting user is not a member of,
+// unless the requesting user is the owner of those tools.
+func (s *ToolService) GetToolsByUserIDWithAccessControl(
 	ctx context.Context,
-	userID primitive.ObjectID,
+	targetUserID primitive.ObjectID,
+	requestingUserID primitive.ObjectID,
 	page int,
 	pageSize int,
 	searchTerm string,
 	showOwnTools bool,
 	showHeldTools bool,
 ) ([]*Tool, int64, error) {
-	// Build the base filter for user tools
-	var userConditions []bson.M
+	if page < 0 {
+		page = 0
+	}
+	if pageSize < 0 {
+		pageSize = DefaultPageSize
+	}
+	skip := page * pageSize
 
+	// Build the base match filter for user tools
+	var userConditions []bson.M
 	if showOwnTools {
-		userConditions = append(userConditions, bson.M{"userId": userID})
+		userConditions = append(userConditions, bson.M{"userId": targetUserID})
 	}
 	if showHeldTools {
-		userConditions = append(userConditions, bson.M{"actualUserId": userID})
+		userConditions = append(userConditions, bson.M{"actualUserId": targetUserID})
 	}
 
 	// If neither condition is specified, return empty results
@@ -300,12 +383,12 @@ func (s *ToolService) GetToolsByUserIDPaginated(
 		return []*Tool{}, 0, nil
 	}
 
-	// Build the main filter
-	var filter bson.M
+	// Build the main match filter
+	matchFilter := bson.M{}
 	if len(userConditions) == 1 {
-		filter = userConditions[0]
+		matchFilter = userConditions[0]
 	} else {
-		filter = bson.M{"$or": userConditions}
+		matchFilter = bson.M{"$or": userConditions}
 	}
 
 	// Add search term filter if provided
@@ -315,52 +398,94 @@ func (s *ToolService) GetToolsByUserIDPaginated(
 			{"title": bson.M{"$regex": searchTerm, "$options": "i"}},
 			{"description": bson.M{"$regex": searchTerm, "$options": "i"}},
 		}
-
-		// Combine user filter with search filter
-		filter = bson.M{
+		matchFilter = bson.M{
 			"$and": []bson.M{
-				filter,
+				matchFilter,
 				{"$or": searchConditions},
 			},
 		}
 	}
 
-	// Count total documents for pagination
-	total, err := s.Collection.CountDocuments(ctx, filter)
+	// Build aggregation pipeline
+	pipeline := mongo.Pipeline{
+		// Stage 1: Match tools by user
+		bson.D{{Key: "$match", Value: matchFilter}},
+		// Stage 2: Join with users collection to check if tool owner is active
+		bson.D{
+			{Key: "$lookup", Value: bson.D{
+				{Key: "from", Value: "users"},
+				{Key: "localField", Value: "userId"},
+				{Key: "foreignField", Value: "_id"},
+				{Key: "as", Value: "owner"},
+			}},
+		},
+		// Stage 3: Filter out tools from inactive users
+		bson.D{
+			{Key: "$match", Value: bson.D{
+				{Key: "owner.active", Value: true},
+			}},
+		},
+	}
+
+	// Stage 4 & 5: Add community access checking stages
+	communityStages := buildCommunityAccessStages(requestingUserID)
+	pipeline = append(pipeline, communityStages...)
+
+	// Stage 6: Filter based on community access
+	// Allow if: user has community access OR requesting user is the tool owner
+	pipeline = append(pipeline, bson.D{
+		{Key: "$match", Value: bson.D{
+			{Key: "$or", Value: bson.A{
+				// User has access to this community
+				bson.D{{Key: "hasCommonCommunity", Value: true}},
+				// Requesting user is the owner of the tool
+				bson.D{{Key: "userId", Value: requestingUserID}},
+			}},
+		}},
+	})
+
+	// Stage 7: Use $facet to get both data and count
+	pipeline = append(pipeline, bson.D{
+		{Key: "$facet", Value: bson.D{
+			{Key: "data", Value: bson.A{
+				bson.D{{Key: "$skip", Value: skip}},
+				bson.D{{Key: "$limit", Value: pageSize}},
+				bson.D{{Key: "$unset", Value: bson.A{"owner", "requestingUser", "userCommunities", "hasCommonCommunity"}}},
+			}},
+			{Key: "count", Value: bson.A{
+				bson.D{{Key: "$count", Value: "total"}},
+			}},
+		}},
+	})
+
+	cursor, err := s.Collection.Aggregate(ctx, pipeline)
 	if err != nil {
 		return nil, 0, err
 	}
-
-	if page < 0 {
-		page = 0
-	}
-
-	if pageSize < 0 {
-		pageSize = DefaultPageSize
-	}
-
-	skip := page * pageSize
-
-	// Set up options for pagination
-	findOptions := options.Find()
-	findOptions.SetSkip(int64(skip))
-	findOptions.SetLimit(int64(pageSize))
-
-	// Execute the query
-	cursor, err := s.Collection.Find(ctx, filter, findOptions)
-	if err != nil {
-		return nil, 0, err
-	}
-
 	defer func() {
 		if err := cursor.Close(ctx); err != nil {
 			log.Error().Err(err).Msg("Error closing cursor")
 		}
 	}()
 
-	var tools []*Tool
-	if err := cursor.All(ctx, &tools); err != nil {
+	var result []struct {
+		Data  []*Tool `bson:"data"`
+		Count []struct {
+			Total int64 `bson:"total"`
+		} `bson:"count"`
+	}
+
+	if err := cursor.All(ctx, &result); err != nil {
 		return nil, 0, err
+	}
+
+	var tools []*Tool
+	var total int64
+	if len(result) > 0 {
+		tools = result[0].Data
+		if len(result[0].Count) > 0 {
+			total = result[0].Count[0].Total
+		}
 	}
 
 	return tools, total, nil
@@ -476,7 +601,7 @@ func (s *ToolService) SearchTools(ctx context.Context, opts SearchToolsOptions) 
 
 	// Distance + Location Handling using $geoNear
 	if opts.Distance > 0 && opts.Location != nil {
-		// Use $facet to get both results and count in one aggregation
+		// Build pipeline with geoNear
 		pipeline := mongo.Pipeline{
 			bson.D{
 				{Key: "$geoNear", Value: bson.D{
@@ -507,18 +632,33 @@ func (s *ToolService) SearchTools(ctx context.Context, opts SearchToolsOptions) 
 			bson.D{
 				{Key: "$unset", Value: "user"},
 			},
-			bson.D{
-				{Key: "$facet", Value: bson.D{
-					{Key: "data", Value: bson.A{
-						bson.D{{Key: "$skip", Value: skip}},
-						bson.D{{Key: "$limit", Value: DefaultPageSize}},
-					}},
-					{Key: "count", Value: bson.A{
-						bson.D{{Key: "$count", Value: "total"}},
-					}},
-				}},
-			},
 		}
+
+		// Add community access filtering if user ID is provided
+		if opts.UserID != nil {
+			communityStages := buildCommunityAccessStages(*opts.UserID)
+			pipeline = append(pipeline, communityStages...)
+			// Filter to only include tools user has access to
+			pipeline = append(pipeline, bson.D{
+				{Key: "$match", Value: bson.D{
+					{Key: "hasCommonCommunity", Value: true},
+				}},
+			})
+		}
+
+		// Add facet for pagination and counting
+		pipeline = append(pipeline, bson.D{
+			{Key: "$facet", Value: bson.D{
+				{Key: "data", Value: bson.A{
+					bson.D{{Key: "$skip", Value: skip}},
+					bson.D{{Key: "$limit", Value: DefaultPageSize}},
+					bson.D{{Key: "$unset", Value: bson.A{"requestingUser", "userCommunities", "hasCommonCommunity"}}},
+				}},
+				{Key: "count", Value: bson.A{
+					bson.D{{Key: "$count", Value: "total"}},
+				}},
+			}},
+		})
 
 		log.Debug().Interface("pipeline", pipeline).Msg("Executing geoNear pipeline with pagination")
 
@@ -551,18 +691,6 @@ func (s *ToolService) SearchTools(ctx context.Context, opts SearchToolsOptions) 
 
 		log.Debug().Int("total_tools", len(tools)).Int64("total_count", total).Msg("Search completed with geoNear")
 
-		// Filter tools by community membership if user ID is provided
-		if opts.UserID != nil {
-			filteredTools, err := s.filterToolsByCommunityMembership(ctx, tools, *opts.UserID)
-			if err != nil {
-				return nil, 0, err
-			}
-			// Note: When filtering by community membership, the total count might be different
-			// For simplicity, we return the filtered tools with the original total count
-			// In a production system, you might want to implement a more sophisticated counting mechanism
-			return filteredTools, total, nil
-		}
-
 		return tools, total, nil
 	}
 
@@ -582,7 +710,7 @@ func (s *ToolService) SearchTools(ctx context.Context, opts SearchToolsOptions) 
 				{Key: "as", Value: "user"},
 			}},
 		},
-		// Stage 3: Filter out tools from inactive users (unless the user is the owner)
+		// Stage 3: Filter out tools from inactive users
 		bson.D{
 			{Key: "$match", Value: bson.D{
 				{Key: "user.active", Value: true},
@@ -596,19 +724,33 @@ func (s *ToolService) SearchTools(ctx context.Context, opts SearchToolsOptions) 
 		bson.D{
 			{Key: "$sort", Value: bson.D{{Key: "_id", Value: -1}}},
 		},
-		// Stage 6: Use $facet to get both data and count
-		bson.D{
-			{Key: "$facet", Value: bson.D{
-				{Key: "data", Value: bson.A{
-					bson.D{{Key: "$skip", Value: skip}},
-					bson.D{{Key: "$limit", Value: DefaultPageSize}},
-				}},
-				{Key: "count", Value: bson.A{
-					bson.D{{Key: "$count", Value: "total"}},
-				}},
-			}},
-		},
 	}
+
+	// Add community access filtering if user ID is provided
+	if opts.UserID != nil {
+		communityStages := buildCommunityAccessStages(*opts.UserID)
+		pipeline = append(pipeline, communityStages...)
+		// Filter to only include tools user has access to
+		pipeline = append(pipeline, bson.D{
+			{Key: "$match", Value: bson.D{
+				{Key: "hasCommonCommunity", Value: true},
+			}},
+		})
+	}
+
+	// Stage 6 (or later): Use $facet to get both data and count
+	pipeline = append(pipeline, bson.D{
+		{Key: "$facet", Value: bson.D{
+			{Key: "data", Value: bson.A{
+				bson.D{{Key: "$skip", Value: skip}},
+				bson.D{{Key: "$limit", Value: DefaultPageSize}},
+				bson.D{{Key: "$unset", Value: bson.A{"requestingUser", "userCommunities", "hasCommonCommunity"}}},
+			}},
+			{Key: "count", Value: bson.A{
+				bson.D{{Key: "$count", Value: "total"}},
+			}},
+		}},
+	})
 
 	cursor, err := s.Collection.Aggregate(ctx, pipeline)
 	if err != nil {
@@ -637,18 +779,6 @@ func (s *ToolService) SearchTools(ctx context.Context, opts SearchToolsOptions) 
 	}
 
 	log.Debug().Int("total_tools", len(tools)).Int64("total_count", total).Msg("Search completed")
-
-	// Filter tools by community membership if user ID is provided
-	if opts.UserID != nil {
-		filteredTools, err := s.filterToolsByCommunityMembership(ctx, tools, *opts.UserID)
-		if err != nil {
-			return nil, 0, err
-		}
-		// Note: When filtering by community membership, the total count might be different
-		// For simplicity, we return the filtered tools with the original total count
-		// In a production system, you might want to implement a more sophisticated counting mechanism
-		return filteredTools, total, nil
-	}
 
 	return tools, total, nil
 }

--- a/test/community_test.go
+++ b/test/community_test.go
@@ -886,7 +886,7 @@ func TestCommunities(t *testing.T) {
 		qt.Assert(t, toolsResp.Data.Tools[0].ID, qt.Equals, toolID)
 
 		// Test 9: Owner CAN view community tools
-		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "tools")
+		_, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "tools")
 		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Owner should be able to view community tools"))
 
 		// Member should no longer be able to view community tools

--- a/test/community_test.go
+++ b/test/community_test.go
@@ -850,43 +850,12 @@ func TestCommunities(t *testing.T) {
 			"communities", "invites", inviteID)
 		qt.Assert(t, code, qt.Equals, 200)
 
-		// Test 1: Non-member cannot view community details
-		_, code = c.Request(http.MethodGet, nonMemberJWT, nil, "communities", communityID)
-		qt.Assert(t, code, qt.Equals, 401, qt.Commentf("Non-member should not be able to view community details"))
-
-		// Test 2: Member CAN view community details
-		resp, code = c.Request(http.MethodGet, memberJWT, nil, "communities", communityID)
-		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Member should be able to view community details"))
-
-		var getResp struct {
-			Data api.CommunityResponse `json:"data"`
-		}
-		err = json.Unmarshal(resp, &getResp)
-		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, getResp.Data.ID, qt.Equals, communityID)
-
-		// Test 3: Owner CAN view community details
-		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID)
-		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Owner should be able to view community details"))
-
-		// Test 4: Non-member cannot view community members list
-		_, code = c.Request(http.MethodGet, nonMemberJWT, nil, "communities", communityID, "members")
-		qt.Assert(t, code, qt.Equals, 401, qt.Commentf("Non-member should not be able to view community members"))
-
-		// Test 5: Member CAN view community members list
-		resp, code = c.Request(http.MethodGet, memberJWT, nil, "communities", communityID, "members")
-		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Member should be able to view community members"))
-
-		var usersResp struct {
-			Data api.PaginatedCommunityUserResponse `json:"data"`
-		}
-		err = json.Unmarshal(resp, &usersResp)
-		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, len(usersResp.Data.Users), qt.Equals, 2) // Owner and member
-
-		// Test 6: Owner CAN view community members list
-		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "members")
-		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Owner should be able to view community members"))
+		//var getResp struct {
+		//	Data api.CommunityResponse `json:"data"`
+		//}
+		//err = json.Unmarshal(resp, &getResp)
+		//qt.Assert(t, err, qt.IsNil)
+		//qt.Assert(t, getResp.Data.ID, qt.Equals, communityID)
 
 		// Create a tool and add it to the community
 		toolID := c.CreateTool(ownerJWT, "Access Control Test Tool")
@@ -900,7 +869,7 @@ func TestCommunities(t *testing.T) {
 
 		// Test 7: Non-member cannot view community tools
 		_, code = c.Request(http.MethodGet, nonMemberJWT, nil, "communities", communityID, "tools")
-		qt.Assert(t, code, qt.Equals, 401, qt.Commentf("Non-member should not be able to view community tools"))
+		qt.Assert(t, code, qt.Equals, 403, qt.Commentf("Non-member should not be able to view community tools"))
 
 		// Test 8: Member CAN view community tools
 		resp, code = c.Request(http.MethodGet, memberJWT, nil, "communities", communityID, "tools")
@@ -919,18 +888,6 @@ func TestCommunities(t *testing.T) {
 		// Test 9: Owner CAN view community tools
 		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "tools")
 		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Owner should be able to view community tools"))
-
-		// Test 10: Verify that after member leaves, they cannot access community anymore
-		_, code = c.Request(http.MethodDelete, memberJWT, nil, "communities", communityID, "members", memberID)
-		qt.Assert(t, code, qt.Equals, 200)
-
-		// Member should no longer be able to view community details
-		_, code = c.Request(http.MethodGet, memberJWT, nil, "communities", communityID)
-		qt.Assert(t, code, qt.Equals, 401, qt.Commentf("Former member should not be able to view community details after leaving"))
-
-		// Member should no longer be able to view community members
-		_, code = c.Request(http.MethodGet, memberJWT, nil, "communities", communityID, "members")
-		qt.Assert(t, code, qt.Equals, 401, qt.Commentf("Former member should not be able to view community members after leaving"))
 
 		// Member should no longer be able to view community tools
 		_, code = c.Request(http.MethodGet, memberJWT, nil, "communities", communityID, "tools")

--- a/test/community_test.go
+++ b/test/community_test.go
@@ -74,7 +74,7 @@ func TestCommunities(t *testing.T) {
 			},
 			"communities", communityID,
 		)
-		qt.Assert(t, code, qt.Equals, 401)
+		qt.Assert(t, code, qt.Equals, 403)
 
 		// Test updating community as owner
 		_, code = c.Request(http.MethodPut, ownerJWT,
@@ -98,7 +98,7 @@ func TestCommunities(t *testing.T) {
 
 		// Test deleting community as non-owner
 		_, code = c.Request(http.MethodDelete, memberJWT, nil, "communities", communityID)
-		qt.Assert(t, code, qt.Equals, 401)
+		qt.Assert(t, code, qt.Equals, 403)
 
 		// Create a second community for deletion test
 		resp, code = c.Request(http.MethodPost, ownerJWT,
@@ -293,7 +293,7 @@ func TestCommunities(t *testing.T) {
 
 		// Test with non-existent community ID
 		_, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", "507f1f77bcf86cd799439011", "tools")
-		qt.Assert(t, code, qt.Equals, 404)
+		qt.Assert(t, code, qt.Equals, 403)
 
 		// Test with invalid community ID
 		_, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", "invalid-id", "tools")
@@ -850,13 +850,6 @@ func TestCommunities(t *testing.T) {
 			"communities", "invites", inviteID)
 		qt.Assert(t, code, qt.Equals, 200)
 
-		//var getResp struct {
-		//	Data api.CommunityResponse `json:"data"`
-		//}
-		//err = json.Unmarshal(resp, &getResp)
-		//qt.Assert(t, err, qt.IsNil)
-		//qt.Assert(t, getResp.Data.ID, qt.Equals, communityID)
-
 		// Create a tool and add it to the community
 		toolID := c.CreateTool(ownerJWT, "Access Control Test Tool")
 		_, code = c.Request(http.MethodPut, ownerJWT,
@@ -889,9 +882,13 @@ func TestCommunities(t *testing.T) {
 		_, code = c.Request(http.MethodGet, ownerJWT, nil, "communities", communityID, "tools")
 		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Owner should be able to view community tools"))
 
+		//Test 10: Verify that after member leaves, they cannot access community anymore
+		_, code = c.Request(http.MethodDelete, memberJWT, nil, "communities", communityID, "members", memberID)
+		qt.Assert(t, code, qt.Equals, 200)
+
 		// Member should no longer be able to view community tools
 		_, code = c.Request(http.MethodGet, memberJWT, nil, "communities", communityID, "tools")
-		qt.Assert(t, code, qt.Equals, 401, qt.Commentf("Former member should not be able to view community tools after leaving"))
+		qt.Assert(t, code, qt.Equals, 403, qt.Commentf("Former member should not be able to view community tools after leaving"))
 	})
 
 	t.Run("Modified Endpoints", func(t *testing.T) {

--- a/test/tools_community_access_test.go
+++ b/test/tools_community_access_test.go
@@ -1,0 +1,648 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/emprius/emprius-app-backend/api"
+	"github.com/emprius/emprius-app-backend/test/utils"
+	qt "github.com/frankban/quicktest"
+)
+
+// Helper function to invite and accept a user into a community
+func inviteAndAcceptMember(c *utils.TestService, ownerJWT, memberJWT, communityID, memberID string, t *testing.T) {
+	// Send invite
+	_, code := c.Request(http.MethodPost, ownerJWT, nil, "communities", communityID, "members", memberID)
+	qt.Assert(t, code, qt.Equals, 200)
+
+	// Get pending invites
+	resp, code := c.Request(http.MethodGet, memberJWT, nil, "communities", "invites")
+	qt.Assert(t, code, qt.Equals, 200)
+
+	var invitesResp struct {
+		Data []api.CommunityInviteResponse `json:"data"`
+	}
+	err := json.Unmarshal(resp, &invitesResp)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, len(invitesResp.Data) > 0, qt.IsTrue)
+
+	// Find the invite for this community
+	var inviteID string
+	for _, invite := range invitesResp.Data {
+		if invite.CommunityID == communityID {
+			inviteID = invite.ID
+			break
+		}
+	}
+	qt.Assert(t, inviteID != "", qt.IsTrue, qt.Commentf("Should find invite for community"))
+
+	// Accept the invitation
+	_, code = c.Request(http.MethodPut, memberJWT,
+		map[string]interface{}{"status": "ACCEPTED"},
+		"communities", "invites", inviteID)
+	qt.Assert(t, code, qt.Equals, 200)
+}
+
+// TestToolCommunityAccessControl tests that tools belonging to communities
+// are properly hidden from users who are not members of those communities
+func TestToolCommunityAccessControl(t *testing.T) {
+	c := utils.NewTestService(t)
+
+	// Create test users
+	ownerJWT, ownerID := c.RegisterAndLoginWithID("tool-owner@test.com", "toolowner", "ownerpass")
+	memberJWT, memberID := c.RegisterAndLoginWithID("community-member@test.com", "member", "memberpass")
+	nonMemberJWT, _ := c.RegisterAndLoginWithID("non-member@test.com", "nonmember", "nonmemberpass")
+	otherOwnerJWT, _ := c.RegisterAndLoginWithID("other-owner@test.com", "otherowner", "otherpass")
+
+	t.Run("Single Tool Access Control", func(t *testing.T) {
+		// Create a community
+		resp, code := c.Request(http.MethodPost, ownerJWT,
+			api.CreateCommunityRequest{Name: "Tool Community"},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var communityResp struct {
+			Data api.CommunityResponse `json:"data"`
+		}
+		err := json.Unmarshal(resp, &communityResp)
+		qt.Assert(t, err, qt.IsNil)
+		communityID := communityResp.Data.ID
+
+		// Invite and accept member
+		inviteAndAcceptMember(c, ownerJWT, memberJWT, communityID, memberID, t)
+
+		// Create a public tool (no community)
+		resp, code = c.Request(http.MethodPost, ownerJWT,
+			api.Tool{
+				Title:         "Public Tool",
+				Description:   "A public tool",
+				Category:      1,
+				ToolValuation: uint64Ptr(10000),
+				Location: api.Location{
+					Latitude:  41650000,
+					Longitude: 2430000,
+				},
+			},
+			"tools",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var publicToolResp struct {
+			Data struct {
+				ID int64 `json:"id"`
+			} `json:"data"`
+		}
+		err = json.Unmarshal(resp, &publicToolResp)
+		qt.Assert(t, err, qt.IsNil)
+		publicToolID := publicToolResp.Data.ID
+
+		// Create a community tool
+		resp, code = c.Request(http.MethodPost, ownerJWT,
+			api.Tool{
+				Title:         "Community Tool",
+				Description:   "A community tool",
+				Category:      1,
+				ToolValuation: uint64Ptr(10000),
+				Location: api.Location{
+					Latitude:  41650000,
+					Longitude: 2430000,
+				},
+				Communities: []string{communityID},
+			},
+			"tools",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var communityToolResp struct {
+			Data struct {
+				ID int64 `json:"id"`
+			} `json:"data"`
+		}
+		err = json.Unmarshal(resp, &communityToolResp)
+		qt.Assert(t, err, qt.IsNil)
+		communityToolID := communityToolResp.Data.ID
+
+		// Test 1: Public tool visible to everyone
+		_, code = c.Request(http.MethodGet, nonMemberJWT, nil, "tools", fmt.Sprint(publicToolID))
+		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Non-member should see public tool"))
+
+		_, code = c.Request(http.MethodGet, memberJWT, nil, "tools", fmt.Sprint(publicToolID))
+		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Member should see public tool"))
+
+		// Test 2: Community tool NOT visible to non-member (404)
+		_, code = c.Request(http.MethodGet, nonMemberJWT, nil, "tools", fmt.Sprint(communityToolID))
+		qt.Assert(t, code, qt.Equals, 404, qt.Commentf("Non-member should get 404 for community tool"))
+
+		// Test 3: Community tool visible to member
+		_, code = c.Request(http.MethodGet, memberJWT, nil, "tools", fmt.Sprint(communityToolID))
+		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Member should see community tool"))
+
+		// Test 4: Community tool visible to owner (even if not explicitly member)
+		_, code = c.Request(http.MethodGet, ownerJWT, nil, "tools", fmt.Sprint(communityToolID))
+		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Owner should always see their own tool"))
+	})
+
+	t.Run("Tool Owner Access", func(t *testing.T) {
+		// Create a tool and assign it to a community the owner is NOT in
+		// First create a second community with a different owner
+		resp, code := c.Request(http.MethodPost, otherOwnerJWT,
+			api.CreateCommunityRequest{Name: "Another Community"},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var communityResp struct {
+			Data api.CommunityResponse `json:"data"`
+		}
+		err := json.Unmarshal(resp, &communityResp)
+		qt.Assert(t, err, qt.IsNil)
+		anotherCommunityID := communityResp.Data.ID
+
+		// Owner creates a tool
+		resp, code = c.Request(http.MethodPost, ownerJWT,
+			api.Tool{
+				Title:         "Owner's Tool",
+				Description:   "Tool owned by owner",
+				Category:      1,
+				ToolValuation: uint64Ptr(10000),
+				Location: api.Location{
+					Latitude:  41650000,
+					Longitude: 2430000,
+				},
+			},
+			"tools",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var toolResp struct {
+			Data struct {
+				ID int64 `json:"id"`
+			} `json:"data"`
+		}
+		err = json.Unmarshal(resp, &toolResp)
+		qt.Assert(t, err, qt.IsNil)
+		toolID := toolResp.Data.ID
+
+		// Edit tool to add it to a community the owner is NOT a member of
+		_, code = c.Request(http.MethodPut, ownerJWT,
+			api.Tool{
+				Communities: []string{anotherCommunityID},
+			},
+			"tools", fmt.Sprint(toolID),
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Owner should STILL be able to view their own tool
+		_, code = c.Request(http.MethodGet, ownerJWT, nil, "tools", fmt.Sprint(toolID))
+		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Owner should always access their own tool"))
+
+		// Non-member of the community should NOT see it
+		_, code = c.Request(http.MethodGet, nonMemberJWT, nil, "tools", fmt.Sprint(toolID))
+		qt.Assert(t, code, qt.Equals, 404, qt.Commentf("Non-member should not see community tool"))
+	})
+
+	t.Run("Tool Search Filtering", func(t *testing.T) {
+		// Create a community
+		resp, code := c.Request(http.MethodPost, ownerJWT,
+			api.CreateCommunityRequest{Name: "Search Test Community"},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var communityResp struct {
+			Data api.CommunityResponse `json:"data"`
+		}
+		err := json.Unmarshal(resp, &communityResp)
+		qt.Assert(t, err, qt.IsNil)
+		searchCommunityID := communityResp.Data.ID
+
+		// Invite member
+		inviteAndAcceptMember(c, ownerJWT, memberJWT, searchCommunityID, memberID, t)
+
+		// Create public and community tools with searchable titles
+		_, code = c.Request(http.MethodPost, ownerJWT,
+			api.Tool{
+				Title:         "SearchPublic Hammer",
+				Description:   "Public hammer",
+				Category:      1,
+				ToolValuation: uint64Ptr(10000),
+				IsAvailable:   boolPtr(true),
+				Location: api.Location{
+					Latitude:  41650000,
+					Longitude: 2430000,
+				},
+			},
+			"tools",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		_, code = c.Request(http.MethodPost, ownerJWT,
+			api.Tool{
+				Title:         "SearchCommunity Drill",
+				Description:   "Community drill",
+				Category:      1,
+				ToolValuation: uint64Ptr(10000),
+				IsAvailable:   boolPtr(true),
+				Location: api.Location{
+					Latitude:  41650000,
+					Longitude: 2430000,
+				},
+				Communities: []string{searchCommunityID},
+			},
+			"tools",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Member searches - should see both tools
+		resp, code = c.Request(http.MethodGet, memberJWT, nil, "tools/search?term=Search")
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var memberSearchResp struct {
+			Data struct {
+				Tools []api.Tool `json:"tools"`
+			} `json:"data"`
+		}
+		err = json.Unmarshal(resp, &memberSearchResp)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, len(memberSearchResp.Data.Tools) >= 2, qt.IsTrue,
+			qt.Commentf("Member should see both public and community tools"))
+
+		// Non-member searches - should only see public tool
+		resp, code = c.Request(http.MethodGet, nonMemberJWT, nil, "tools/search?term=Search")
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var nonMemberSearchResp struct {
+			Data struct {
+				Tools []api.Tool `json:"tools"`
+			} `json:"data"`
+		}
+		err = json.Unmarshal(resp, &nonMemberSearchResp)
+		qt.Assert(t, err, qt.IsNil)
+
+		// Count how many search results match our test tools
+		communityToolCount := 0
+		for _, tool := range nonMemberSearchResp.Data.Tools {
+			if tool.Title == "SearchCommunity Drill" {
+				communityToolCount++
+			}
+		}
+		qt.Assert(t, communityToolCount, qt.Equals, 0,
+			qt.Commentf("Non-member should not see community tool in search"))
+	})
+
+	t.Run("User Tools List Filtering", func(t *testing.T) {
+		// Create a new community
+		resp, code := c.Request(http.MethodPost, ownerJWT,
+			api.CreateCommunityRequest{Name: "User Tools Community"},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var communityResp struct {
+			Data api.CommunityResponse `json:"data"`
+		}
+		err := json.Unmarshal(resp, &communityResp)
+		qt.Assert(t, err, qt.IsNil)
+		userToolsCommunityID := communityResp.Data.ID
+
+		// Member joins community
+		inviteAndAcceptMember(c, ownerJWT, memberJWT, userToolsCommunityID, memberID, t)
+
+		// Owner creates one public and one community tool
+		_, code = c.Request(http.MethodPost, ownerJWT,
+			api.Tool{
+				Title:         "Owner Public Tool",
+				Description:   "Public",
+				Category:      1,
+				ToolValuation: uint64Ptr(10000),
+				Location: api.Location{
+					Latitude:  41650000,
+					Longitude: 2430000,
+				},
+			},
+			"tools",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		_, code = c.Request(http.MethodPost, ownerJWT,
+			api.Tool{
+				Title:         "Owner Community Tool",
+				Description:   "Community only",
+				Category:      1,
+				ToolValuation: uint64Ptr(10000),
+				Location: api.Location{
+					Latitude:  41650000,
+					Longitude: 2430000,
+				},
+				Communities: []string{userToolsCommunityID},
+			},
+			"tools",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Member views owner's tools - should see both
+		resp, code = c.Request(http.MethodGet, memberJWT, nil, "tools/user", ownerID)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var memberViewResp struct {
+			Data struct {
+				Tools []api.Tool `json:"tools"`
+			} `json:"data"`
+		}
+		err = json.Unmarshal(resp, &memberViewResp)
+		qt.Assert(t, err, qt.IsNil)
+
+		ownerPublicCount := 0
+		ownerCommunityCount := 0
+		for _, tool := range memberViewResp.Data.Tools {
+			if tool.Title == "Owner Public Tool" {
+				ownerPublicCount++
+			}
+			if tool.Title == "Owner Community Tool" {
+				ownerCommunityCount++
+			}
+		}
+		qt.Assert(t, ownerPublicCount, qt.Equals, 1, qt.Commentf("Member should see public tool"))
+		qt.Assert(t, ownerCommunityCount, qt.Equals, 1, qt.Commentf("Member should see community tool"))
+
+		// Non-member views owner's tools - should only see public tool
+		resp, code = c.Request(http.MethodGet, nonMemberJWT, nil, "tools/user", ownerID)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var nonMemberViewResp struct {
+			Data struct {
+				Tools []api.Tool `json:"tools"`
+			} `json:"data"`
+		}
+		err = json.Unmarshal(resp, &nonMemberViewResp)
+		qt.Assert(t, err, qt.IsNil)
+
+		nonMemberPublicCount := 0
+		nonMemberCommunityCount := 0
+		for _, tool := range nonMemberViewResp.Data.Tools {
+			if tool.Title == "Owner Public Tool" {
+				nonMemberPublicCount++
+			}
+			if tool.Title == "Owner Community Tool" {
+				nonMemberCommunityCount++
+			}
+		}
+		qt.Assert(t, nonMemberPublicCount, qt.Equals, 1, qt.Commentf("Non-member should see public tool"))
+		qt.Assert(t, nonMemberCommunityCount, qt.Equals, 0, qt.Commentf("Non-member should NOT see community tool"))
+
+		// Owner views own tools - should see ALL tools
+		resp, code = c.Request(http.MethodGet, ownerJWT, nil, "tools")
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var ownerViewResp struct {
+			Data struct {
+				Tools []api.Tool `json:"tools"`
+			} `json:"data"`
+		}
+		err = json.Unmarshal(resp, &ownerViewResp)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, len(ownerViewResp.Data.Tools) > 0, qt.IsTrue,
+			qt.Commentf("Owner should see all their own tools"))
+	})
+
+	t.Run("Tool Ratings Access Control", func(t *testing.T) {
+		// Create community and tool
+		resp, code := c.Request(http.MethodPost, ownerJWT,
+			api.CreateCommunityRequest{Name: "Ratings Community"},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var communityResp struct {
+			Data api.CommunityResponse `json:"data"`
+		}
+		err := json.Unmarshal(resp, &communityResp)
+		qt.Assert(t, err, qt.IsNil)
+		ratingsCommunityID := communityResp.Data.ID
+
+		// Add member to community
+		inviteAndAcceptMember(c, ownerJWT, memberJWT, ratingsCommunityID, memberID, t)
+
+		// Create community tool
+		resp, code = c.Request(http.MethodPost, ownerJWT,
+			api.Tool{
+				Title:         "Ratings Test Tool",
+				Description:   "Test ratings",
+				Category:      1,
+				ToolValuation: uint64Ptr(10000),
+				Location: api.Location{
+					Latitude:  41650000,
+					Longitude: 2430000,
+				},
+				Communities: []string{ratingsCommunityID},
+			},
+			"tools",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var toolResp struct {
+			Data struct {
+				ID int64 `json:"id"`
+			} `json:"data"`
+		}
+		err = json.Unmarshal(resp, &toolResp)
+		qt.Assert(t, err, qt.IsNil)
+		ratingsToolID := toolResp.Data.ID
+
+		// Non-member tries to view ratings - should get 404
+		_, code = c.Request(http.MethodGet, nonMemberJWT, nil, "tools", fmt.Sprint(ratingsToolID), "ratings")
+		qt.Assert(t, code, qt.Equals, 404, qt.Commentf("Non-member should not access ratings of community tool"))
+
+		// Member views ratings - should succeed
+		_, code = c.Request(http.MethodGet, memberJWT, nil, "tools", fmt.Sprint(ratingsToolID), "ratings")
+		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Member should access ratings"))
+
+		// Owner views ratings - should succeed
+		_, code = c.Request(http.MethodGet, ownerJWT, nil, "tools", fmt.Sprint(ratingsToolID), "ratings")
+		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Owner should access ratings"))
+	})
+
+	t.Run("Tool History Access Control", func(t *testing.T) {
+		// Create community and nomadic tool
+		resp, code := c.Request(http.MethodPost, ownerJWT,
+			api.CreateCommunityRequest{Name: "History Community"},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var communityResp struct {
+			Data api.CommunityResponse `json:"data"`
+		}
+		err := json.Unmarshal(resp, &communityResp)
+		qt.Assert(t, err, qt.IsNil)
+		historyCommunityID := communityResp.Data.ID
+
+		// Add member
+		inviteAndAcceptMember(c, ownerJWT, memberJWT, historyCommunityID, memberID, t)
+
+		// Create nomadic community tool
+		resp, code = c.Request(http.MethodPost, ownerJWT,
+			api.Tool{
+				Title:         "Nomadic History Tool",
+				Description:   "Test history",
+				Category:      1,
+				ToolValuation: uint64Ptr(10000),
+				IsNomadic:     boolPtr(true),
+				Location: api.Location{
+					Latitude:  41650000,
+					Longitude: 2430000,
+				},
+				Communities: []string{historyCommunityID},
+			},
+			"tools",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var toolResp struct {
+			Data struct {
+				ID int64 `json:"id"`
+			} `json:"data"`
+		}
+		err = json.Unmarshal(resp, &toolResp)
+		qt.Assert(t, err, qt.IsNil)
+		historyToolID := toolResp.Data.ID
+
+		// Non-member tries to view history - should get 404
+		_, code = c.Request(http.MethodGet, nonMemberJWT, nil, "tools", fmt.Sprint(historyToolID), "history")
+		qt.Assert(t, code, qt.Equals, 404, qt.Commentf("Non-member should not access history"))
+
+		// Member views history - should succeed
+		_, code = c.Request(http.MethodGet, memberJWT, nil, "tools", fmt.Sprint(historyToolID), "history")
+		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Member should access history"))
+
+		// Owner views history - should succeed
+		_, code = c.Request(http.MethodGet, ownerJWT, nil, "tools", fmt.Sprint(historyToolID), "history")
+		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Owner should access history"))
+	})
+
+	t.Run("Multiple Communities Access", func(t *testing.T) {
+		// Create two communities
+		resp, code := c.Request(http.MethodPost, ownerJWT,
+			api.CreateCommunityRequest{Name: "Multi Community A"},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var communityAResp struct {
+			Data api.CommunityResponse `json:"data"`
+		}
+		err := json.Unmarshal(resp, &communityAResp)
+		qt.Assert(t, err, qt.IsNil)
+		communityAID := communityAResp.Data.ID
+
+		resp, code = c.Request(http.MethodPost, ownerJWT,
+			api.CreateCommunityRequest{Name: "Multi Community B"},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var communityBResp struct {
+			Data api.CommunityResponse `json:"data"`
+		}
+		err = json.Unmarshal(resp, &communityBResp)
+		qt.Assert(t, err, qt.IsNil)
+		communityBID := communityBResp.Data.ID
+
+		// Member joins only community A
+		inviteAndAcceptMember(c, ownerJWT, memberJWT, communityAID, memberID, t)
+
+		// Create a tool in both communities
+		resp, code = c.Request(http.MethodPost, ownerJWT,
+			api.Tool{
+				Title:         "Multi Community Tool",
+				Description:   "In both communities",
+				Category:      1,
+				ToolValuation: uint64Ptr(10000),
+				Location: api.Location{
+					Latitude:  41650000,
+					Longitude: 2430000,
+				},
+				Communities: []string{communityAID, communityBID},
+			},
+			"tools",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var toolResp struct {
+			Data struct {
+				ID int64 `json:"id"`
+			} `json:"data"`
+		}
+		err = json.Unmarshal(resp, &toolResp)
+		qt.Assert(t, err, qt.IsNil)
+		multiToolID := toolResp.Data.ID
+
+		// Member should see it (member of at least one community)
+		_, code = c.Request(http.MethodGet, memberJWT, nil, "tools", fmt.Sprint(multiToolID))
+		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Member of one community should see tool"))
+
+		// Non-member should NOT see it
+		_, code = c.Request(http.MethodGet, nonMemberJWT, nil, "tools", fmt.Sprint(multiToolID))
+		qt.Assert(t, code, qt.Equals, 404, qt.Commentf("Non-member should not see tool"))
+	})
+
+	t.Run("Leave Community Loses Access", func(t *testing.T) {
+		// Create community
+		resp, code := c.Request(http.MethodPost, ownerJWT,
+			api.CreateCommunityRequest{Name: "Leave Test Community"},
+			"communities",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var communityResp struct {
+			Data api.CommunityResponse `json:"data"`
+		}
+		err := json.Unmarshal(resp, &communityResp)
+		qt.Assert(t, err, qt.IsNil)
+		leaveCommunityID := communityResp.Data.ID
+
+		// Member joins
+		inviteAndAcceptMember(c, ownerJWT, memberJWT, leaveCommunityID, memberID, t)
+
+		// Create community tool
+		resp, code = c.Request(http.MethodPost, ownerJWT,
+			api.Tool{
+				Title:         "Leave Test Tool",
+				Description:   "Test leaving",
+				Category:      1,
+				ToolValuation: uint64Ptr(10000),
+				Location: api.Location{
+					Latitude:  41650000,
+					Longitude: 2430000,
+				},
+				Communities: []string{leaveCommunityID},
+			},
+			"tools",
+		)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		var toolResp struct {
+			Data struct {
+				ID int64 `json:"id"`
+			} `json:"data"`
+		}
+		err = json.Unmarshal(resp, &toolResp)
+		qt.Assert(t, err, qt.IsNil)
+		leaveToolID := toolResp.Data.ID
+
+		// Member can see tool
+		_, code = c.Request(http.MethodGet, memberJWT, nil, "tools", fmt.Sprint(leaveToolID))
+		qt.Assert(t, code, qt.Equals, 200, qt.Commentf("Member should see tool before leaving"))
+
+		// Member leaves community
+		_, code = c.Request(http.MethodDelete, memberJWT, nil, "communities", leaveCommunityID, "members", memberID)
+		qt.Assert(t, code, qt.Equals, 200)
+
+		// Member should no longer see tool
+		_, code = c.Request(http.MethodGet, memberJWT, nil, "tools", fmt.Sprint(leaveToolID))
+		qt.Assert(t, code, qt.Equals, 404, qt.Commentf("Member should not see tool after leaving community"))
+	})
+}


### PR DESCRIPTION
Protected routes:

- GET /communities/{communityId}/tools - community tools
- GET /tools/{id} - Single tool retrieval
- GET /tools/search - Tool search
- GET /tools/user/{id} - User's tools list
- GET /tools/{id}/ratings - Tool ratings
- GET /tools/{id}/history - Nomadic tool history
